### PR TITLE
docs: add golden-standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
 # Dutch Law MCP Server
 
-Production-grade [Model Context Protocol](https://modelcontextprotocol.io/) server for Dutch legal research. Provides AI assistants with structured access to 3,248 Dutch statutes, 903,000+ court decisions, 21,000+ kamerstukken, and 1,000+ EU cross-references.
+**The Wetten.overheid.nl alternative for the AI age.**
+
+[![npm version](https://badge.fury.io/js/@ansvar%2Fdutch-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/dutch-law-mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/Dutch-law-mcp?style=social)](https://github.com/Ansvar-Systems/Dutch-law-mcp)
+[![CI](https://github.com/Ansvar-Systems/Dutch-law-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Ansvar-Systems/Dutch-law-mcp/actions/workflows/ci.yml)
+[![Daily Data Check](https://github.com/Ansvar-Systems/Dutch-law-mcp/actions/workflows/check-updates.yml/badge.svg)](https://github.com/Ansvar-Systems/Dutch-law-mcp/actions/workflows/check-updates.yml)
+[![Database](https://img.shields.io/badge/database-pre--built-green)](docs/EU_INTEGRATION_GUIDE.md)
+[![Provisions](https://img.shields.io/badge/provisions-13%2C815-blue)](docs/EU_INTEGRATION_GUIDE.md)
+
+Query **46 key Dutch statutes** -- from the AVG and Wetboek van Strafrecht to the Burgerlijk Wetboek, Mededingingswet, and more -- directly from Claude, Cursor, or any MCP-compatible client.
+
+If you're building legal tech, compliance tools, or doing Dutch legal research, this is your verified reference database.
+
+Built by [Ansvar Systems](https://ansvar.eu) -- Stockholm, Sweden
+
+---
+
+## Why This Exists
+
+Dutch legal research is scattered across Wetten.overheid.nl, Rechtspraak.nl, Kamerstukken, and EUR-Lex. Whether you're:
+- A **lawyer** validating citations in a brief or contract
+- A **compliance officer** checking AVG obligations or Mededingingswet requirements
+- A **legal tech developer** building tools on Dutch law
+- A **researcher** tracing legislative history from Kamerstukken to wet
+
+...you shouldn't need dozens of browser tabs and manual PDF cross-referencing. Ask Claude. Get the exact provision. With context.
+
+This MCP server makes Dutch law **searchable, cross-referenceable, and AI-readable**.
+
+---
 
 ## Quick Start
 
 ### Use Remotely (No Install Needed)
 
-> Connect directly to the hosted version — zero dependencies, nothing to install.
+> Connect directly to the hosted version -- zero dependencies, nothing to install.
 
 **Endpoint:** `https://dutch-law-mcp.vercel.app/mcp`
 
-| Client             | How to Connect                                                                   |
-| ------------------ | -------------------------------------------------------------------------------- |
-| **Claude.ai**      | Settings > Connectors > Add Integration > paste URL                              |
-| **Claude Code**    | `claude mcp add dutch-law --transport http https://dutch-law-mcp.vercel.app/mcp` |
-| **Claude Desktop** | Add to config (see below)                                                        |
-| **GitHub Copilot** | Add to VS Code settings (see below)                                              |
+| Client | How to Connect |
+|--------|---------------|
+| **Claude.ai** | Settings > Connectors > Add Integration > paste URL |
+| **Claude Code** | `claude mcp add dutch-law --transport http https://dutch-law-mcp.vercel.app/mcp` |
+| **Claude Desktop** | Add to config (see below) |
+| **GitHub Copilot** | Add to VS Code settings (see below) |
 
-**Claude Desktop** — add to `claude_desktop_config.json`:
+**Claude Desktop** -- add to `claude_desktop_config.json`:
 
 ```json
 {
@@ -30,7 +61,7 @@ Production-grade [Model Context Protocol](https://modelcontextprotocol.io/) serv
 }
 ```
 
-**GitHub Copilot** — add to VS Code `settings.json`:
+**GitHub Copilot** -- add to VS Code `settings.json`:
 
 ```json
 {
@@ -49,7 +80,7 @@ Production-grade [Model Context Protocol](https://modelcontextprotocol.io/) serv
 npx @ansvar/dutch-law-mcp
 ```
 
-**Claude Desktop** — add to `claude_desktop_config.json`:
+**Claude Desktop** -- add to `claude_desktop_config.json`:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
@@ -78,249 +109,219 @@ npx @ansvar/dutch-law-mcp
 }
 ```
 
-## Available Tools
+---
 
-| Tool                        | Description                                                                       |
-| --------------------------- | --------------------------------------------------------------------------------- |
-| `search_legislation`        | Full-text search across Dutch statutes and regulations (FTS5-indexed)             |
-| `get_provision`             | Retrieve a specific provision by BWB-ID, book, and article (e.g., Art. 6:162 BW)  |
-| `search_case_law`           | Search Dutch court decisions with filters for court, legal domain, and date range |
-| `get_preparatory_works`     | Get kamerstukken (parliamentary documents) for a statute                          |
-| `validate_citation`         | Validate Dutch legal citations and check database existence                       |
-| `build_legal_stance`        | Build comprehensive research bundles combining statutes, case law, and travaux    |
-| `format_citation`           | Format citations to standard Dutch legal citation format                          |
-| `check_currency`            | Check whether a statute or provision is currently in force (geldend recht)        |
-| `get_eu_basis`              | Get EU legal basis (directives/regulations) for a Dutch statute                   |
-| `get_dutch_implementations` | Find Dutch statutes implementing a given EU directive or regulation               |
-| `search_eu_implementations` | Search EU instruments and their Dutch implementations                             |
-| `get_provision_eu_basis`    | Get EU references for a specific provision                                        |
-| `validate_eu_compliance`    | Validate EU compliance for a Dutch statute or provision                           |
-| `get_provision_at_date`     | Retrieve a specific provision as it was at a given date (historical versioning)   |
+## Example Queries
 
-## Data Sources
+Once connected, just ask naturally in Dutch or English:
 
-| Source                 | Description                                                          | URL                               |
-| ---------------------- | -------------------------------------------------------------------- | --------------------------------- |
-| **wetten.overheid.nl** | Official BWB (Basiswettenbestand) for Dutch statutes and regulations | https://wetten.overheid.nl        |
-| **rechtspraak.nl**     | Open data portal for Dutch court decisions                           | https://uitspraken.rechtspraak.nl |
-| **EUR-Lex**            | Official EU legislation database                                     | https://eur-lex.europa.eu         |
+- *"Wat zegt de AVG artikel 5 over de beginselen voor de verwerking van persoonsgegevens?"*
+- *"Is de Mededingingswet artikel 24 over misbruik van machtspositie nog van kracht?"*
+- *"Zoek bepalingen over gegevensbescherming in de Nederlandse wet"*
+- *"Welke EU-richtlijnen implementeert de AVG?"*
+- *"Valideer de citatie 'Wetboek van Strafrecht artikel 138b'"*
+- *"Bouw een juridisch standpunt op over privacyrecht in Nederland"*
+- *"What does Burgerlijk Wetboek Boek 6 say about contractual liability?"*
+- *"Find provisions about trade secrets in Dutch law"*
 
-All data is sourced from official open data portals and stored locally in a SQLite database for fast, offline-capable lookups.
+---
 
-## Data Coverage
+## What's Included
 
-| Metric           | Count                                          |
-| ---------------- | ---------------------------------------------- |
-| **Statutes**     | 3,248 (wetten, AMvBs, ministerial regulations) |
-| **Provisions**   | 79,967 individual articles                     |
-| **Case law**     | 903,000+ court decisions (ECLI-indexed)        |
-| **Kamerstukken** | 21,891 parliamentary documents                 |
-| **EU documents** | 1,008 directives and regulations               |
-| **Definitions**  | 64 extracted legal terms                       |
+| Category | Count | Details |
+|----------|-------|---------|
+| **Statutes** | 46 laws | Key Dutch federal legislation from Wetten.overheid.nl |
+| **Provisions** | 13,815 sections | Full-text searchable with FTS5 |
+| **Premium: Case Law** | 59,261 rulings | Hoge Raad, Gerechtshoven decisions |
+| **Premium: Preparatory Works** | 2,994 documents | Kamerstukken, memorie van toelichting |
+| **Database Size** | 134 MB | Optimized SQLite, portable |
+| **Daily Updates** | Automated | Freshness checks against Wetten.overheid.nl |
 
-## Supported Citation Formats
+### Key Statutes Covered
 
-- **Statute articles**: `Art. 6:162 BW`, `art. 287 Sr`, `art. 8:1 Awb`
-- **ECLI references**: `ECLI:NL:HR:2019:376`
-- **Kamerstukken**: `Kamerstukken II 2020/21, 35815, nr. 2`
-- **EU instruments**: `Verordening (EU) 2016/679`, `Richtlijn 95/46/EG`
+| Statute | Subject |
+|---------|---------|
+| Burgerlijk Wetboek (Boek 1–10) | Civil Code -- persons, property, contracts, tort |
+| Wetboek van Strafrecht | Criminal Code |
+| Algemene wet bestuursrecht | General Administrative Law Act |
+| Uitvoeringswet Algemene verordening gegevensbescherming (AVG) | GDPR implementation |
+| Mededingingswet | Competition Act |
+| Auteurswet | Copyright Act |
+| Arbeidsomstandighedenwet | Working Conditions Act |
+| Wet bescherming bedrijfsgeheimen | Trade Secrets Act |
+| Telecommunicatiewet | Telecommunications Act (ePrivacy) |
+| Wet op het financieel toezicht (Wft) | Financial Supervision Act |
 
-## Development
+**Verified data only** -- every citation is validated against official sources (Wetten.overheid.nl, Overheid.nl). Zero LLM-generated content.
 
-### Prerequisites
+---
 
-- Node.js >= 18
-- npm
+## See It In Action
 
-### Setup
+### Why This Works
 
-```bash
-git clone https://github.com/Ansvar-Systems/Dutch-law-mcp.git
-cd Dutch-law-mcp
-npm install
+**Verbatim Source Text (No LLM Processing):**
+- All statute text is ingested from Wetten.overheid.nl official sources via the BWB API
+- Provisions are returned **unchanged** from SQLite FTS5 database rows
+- Zero LLM summarization or paraphrasing -- the database contains regulation text, not AI interpretations
+
+**Smart Context Management:**
+- Search returns ranked provisions with BM25 scoring (safe for context)
+- Provision retrieval gives exact text by BWB identifier + chapter/article
+- Cross-references help navigate without loading everything at once
+
+**Technical Architecture:**
+```
+Wetten.overheid.nl BWB API → Parse → SQLite → FTS5 snippet() → MCP response
+                                ↑                      ↑
+                       Provision parser         Verbatim database query
 ```
 
-### Building
+### Traditional Research vs. This MCP
 
-```bash
-npm run build
-```
+| Traditional Approach | This MCP Server |
+|---------------------|-----------------|
+| Search Wetten.overheid.nl by wet name | Search by plain Dutch: *"persoonsgegevens verwerking"* |
+| Navigate multi-boek statutes manually | Get the exact provision with context |
+| Manual cross-referencing between wetten | `build_legal_stance` aggregates across sources |
+| "Is this statute still in force?" → check manually | `check_currency` tool → answer in seconds |
+| Find EU basis → dig through EUR-Lex | `get_eu_basis` → linked EU directives instantly |
+| Check Kamerstukken.nl separately | Premium `get_preparatory_works` → linked documents |
+| No API, no integration | MCP protocol → AI-native |
 
-### Testing
+**Traditional:** Search Wetten.overheid.nl → Open BWB page → Navigate articles → Check Kamerstukken → EUR-Lex for EU basis → Repeat
 
-```bash
-npm test                # Run all tests
-npm run test:watch      # Watch mode
-npm run test:coverage   # With coverage report
-```
+**This MCP:** *"What EU law is the basis for AVG artikel 5 about data processing principles?"* → Done.
 
-### Linting and Formatting
+---
 
-```bash
-npm run lint           # Check for lint errors
-npm run lint:fix       # Auto-fix lint errors
-npm run format         # Format all files
-npm run format:check   # Check formatting
-```
+## Available Tools (13)
 
-Pre-commit hooks via Husky and lint-staged automatically run ESLint and Prettier on staged files.
+### Core Legal Research Tools (8)
 
-### Ingestion Scripts
+| Tool | Description |
+|------|-------------|
+| `search_legislation` | FTS5 search on 13,815 provisions with BM25 ranking |
+| `get_provision` | Retrieve specific provision by wet identifier + article number |
+| `search_case_law` | FTS5 search on case law with court/date filters |
+| `get_preparatory_works` | Get linked Kamerstukken and memorie van toelichting for a statute |
+| `validate_citation` | Validate citation against database (zero-hallucination check) |
+| `build_legal_stance` | Aggregate citations from statutes, case law, prep works |
+| `format_citation` | Format citations per Dutch conventions (full/short/pinpoint) |
+| `check_currency` | Check if statute is in force, amended, or repealed |
 
-```bash
-npm run ingest              # Ingest statutes from wetten.overheid.nl (BWB)
-npm run ingest:all          # Comprehensive ingestion of ALL Dutch statutes
-npm run ingest:cases        # Ingest case law from rechtspraak.nl
-npm run ingest:prep-works   # Ingest kamerstukken (parliamentary documents)
-npm run build:db            # Build the SQLite database from seed files
-npm run audit:seeds         # Validate seed file schema compliance
-npm run check-updates       # Check for legal data updates
-npm run extract:definitions # Extract legal term definitions from statutes
-npm run fetch:eurlex        # Fetch EU document metadata from EUR-Lex
-npm run import:eurlex-documents  # Import EU law references into database
-```
+### EU Law Integration Tools (5)
 
-### Project Structure
+| Tool | Description |
+|------|-------------|
+| `get_eu_basis` | Get EU directives/regulations that a Dutch statute implements |
+| `get_dutch_implementations` | Find Dutch laws implementing a specific EU act |
+| `search_eu_implementations` | Search EU documents with Dutch implementation counts |
+| `get_provision_eu_basis` | Get EU law references for a specific provision |
+| `validate_eu_compliance` | Check implementation status (requires EU MCP) |
 
-```
-src/
-  index.ts              # MCP server entry point (stdio)
-  http-server.ts        # HTTP server entry point (Streamable HTTP)
-  tools/
-    registry.ts         # Shared tool definitions and handler registration
-    ...                 # 14 MCP tool implementations
-  parsers/              # BWB XML parser, EU reference parser, amendment parser, cross-ref extractor
-  citation/             # Citation parsing and formatting
-  types/                # TypeScript type definitions
-  utils/
-    ensure-database.ts  # Download-on-first-run database management
-    ...                 # Other shared utilities
-scripts/                # Ingestion and build scripts
-tests/                  # Vitest test suites
-docs/                   # EU integration guide, coverage limitations
-data/
-  seed/                 # JSON seed files (one per statute/batch)
-  database.db           # SQLite database (built from seeds)
-```
+---
 
-## Docker
+## EU Law Integration
 
-### Build and run (stdio mode, default)
+Netherlands is a founding EU member state. Dutch law directly transposes EU directives across the full acquis communautaire.
 
-```bash
-docker build -t dutch-law-mcp .
-docker run --rm -i dutch-law-mcp
-```
+| Metric | Value |
+|--------|-------|
+| **EU Member State** | Yes (founding member, since 1958) |
+| **GDPR Status** | Directly applicable; implemented by Uitvoeringswet AVG |
+| **Key Implementation** | AVG → Uitvoeringswet Algemene verordening gegevensbescherming |
+| **Competition Law** | Mededingingswet implements EU Treaty Articles 101-102 |
+| **ePrivacy** | Telecommunicatiewet transposes ePrivacy Directive |
 
-### HTTP mode
+### Dutch Law and EU Directives
 
-```bash
-docker run --rm -e MODE=http -p 3000:3000 dutch-law-mcp
-```
+- **AVG (GDPR)** -- GDPR is directly applicable in the Netherlands. The Uitvoeringswet AVG implements the member-state derogations and supplements. The `get_eu_basis` tool links AVG provisions to the underlying GDPR articles.
+- **ePrivacy Directive** -- transposed via the Telecommunicatiewet, governing electronic communications and cookie consent.
+- **Competition law** -- Mededingingswet aligns with EU Treaty Articles 101 (cartels) and 102 (abuse of dominance) and Commission enforcement practice.
+- **Trade Secrets Directive** -- implemented by Wet bescherming bedrijfsgeheimen (2018).
+- **Financial regulation** -- Wet op het financieel toezicht (Wft) transposes MiFID II, the Capital Requirements Directive, and related EU financial services directives.
 
-Verify with:
+The EU bridge tools provide bi-directional lookup: start from a Dutch provision to find its EU basis, or start from an EU directive to find its Dutch implementation.
 
-```bash
-curl http://localhost:3000/health
-```
+See [EU_INTEGRATION_GUIDE.md](docs/EU_INTEGRATION_GUIDE.md) for detailed documentation.
 
-### Docker Compose
+---
 
-```bash
-docker compose up -d
-```
+## Premium Tier
 
-The Docker image uses a multi-stage build with a non-root user for security. The database is baked into the image at build time.
+The free tier includes all 13,815 provisions with full-text search and EU cross-references. The premium tier adds version history and legislative document access.
 
-## Deployment
+| Feature | Free | Premium |
+|---------|------|---------|
+| Statute search (13,815 provisions) | Yes | Yes |
+| EU cross-references | Yes | Yes |
+| Citation validation | Yes | Yes |
+| Case law (59,261 rulings) | -- | Yes |
+| Preparatory works (2,994 documents) | -- | Yes |
+| Provision version history | -- | Yes |
+| Amendment diffs | -- | Yes |
 
-### Railway
+**Premium case law** covers decisions from the Hoge Raad (Supreme Court), Gerechtshoven (Courts of Appeal), and Rechtbanken (District Courts) sourced from Rechtspraak.nl.
 
-```bash
-railway init
-railway up
-```
+**Premium preparatory works** covers Kamerstukken (parliamentary documents), memorie van toelichting (explanatory memoranda), and other preparatory materials from Overheid.nl.
 
-Set environment variables:
+Premium is enabled via `PREMIUM_ENABLED=true` environment variable. Contact [hello@ansvar.ai](mailto:hello@ansvar.ai) for access.
 
-- `MODE=http`
-- `PORT` is set automatically by Railway
+---
 
-### Fly.io
+## Data Sources & Freshness
 
-```bash
-fly launch
-fly deploy
-```
+All content is sourced from authoritative Dutch legal databases:
 
-In `fly.toml`:
+- **[Wetten.overheid.nl](https://wetten.overheid.nl/)** -- Official consolidated statutes, Ministerie van Justitie en Veiligheid
+- **[Rechtspraak.nl](https://www.rechtspraak.nl/)** -- Official court decisions database
+- **[Overheid.nl](https://www.overheid.nl/)** -- Official government publications portal
+- **[EUR-Lex](https://eur-lex.europa.eu/)** -- Official EU law database (metadata)
 
-```toml
-[env]
-  MODE = "http"
+### Data Provenance
 
-[[services]]
-  internal_port = 3000
-```
+| Field | Value |
+|-------|-------|
+| **Authority** | Ministerie van Justitie en Veiligheid / Overheid.nl |
+| **Retrieval method** | Bulk download from Wetten.overheid.nl BWB API |
+| **Language** | Dutch (primary) |
+| **License** | Open Government License -- Netherlands |
+| **Coverage** | 46 key Dutch federal laws |
+| **Last ingested** | 2026-02-22 |
 
-### Vercel (Serverless)
+### Automated Freshness Checks (Daily)
 
-Deploy as a serverless function — no long-running server needed:
+A [daily GitHub Actions workflow](.github/workflows/check-updates.yml) monitors all data sources:
 
-```bash
-npm i -g vercel    # Install Vercel CLI (once)
-vercel deploy      # Deploy to preview
-vercel --prod      # Deploy to production
-```
+| Source | Check | Method |
+|--------|-------|--------|
+| **Statute amendments** | Wetten.overheid.nl date comparison | All 46 statutes checked |
+| **New statutes** | BWB API publications (90-day window) | Diffed against database |
+| **Case law** | Rechtspraak.nl feed entry count | Compared to database |
+| **Preparatory works** | Overheid.nl Kamerstukken feed (30-day window) | New docs detected |
+| **EU reference staleness** | Git commit timestamps | Flagged if >90 days old |
 
-The serverless handler at `api/mcp.ts` downloads the ~1 GB SQLite database from GitHub Releases on cold start, decompresses it to `/tmp`, and caches it across warm invocations. The WASM-based SQLite driver (`node-sqlite3-wasm`) works on Vercel without native compilation.
+---
 
-**Note:** Requires Vercel Pro plan (1 GB `/tmp` storage) and `maxDuration >= 60` for cold-start downloads. Override the download URL with `DUTCH_LAW_DB_URL` if needed.
+## Security
 
-| Endpoint  | Method | Description                              |
-| --------- | ------ | ---------------------------------------- |
-| `/health` | GET    | Health check (`{ "status": "ok" }`)      |
-| `/mcp`    | GET    | Server metadata JSON                     |
-| `/mcp`    | POST   | MCP protocol (stateless Streamable HTTP) |
+This project uses multiple layers of automated security scanning:
 
-## Releasing
+| Scanner | What It Does | Schedule |
+|---------|-------------|----------|
+| **CodeQL** | Static analysis for security vulnerabilities | Weekly + PRs |
+| **Semgrep** | SAST scanning (OWASP top 10, secrets, TypeScript) | Every push |
+| **Gitleaks** | Secret detection across git history | Every push |
+| **Trivy** | CVE scanning on filesystem and npm dependencies | Daily |
+| **Docker Security** | Container image scanning + SBOM generation | Daily |
+| **Socket.dev** | Supply chain attack detection | PRs |
+| **OSSF Scorecard** | OpenSSF best practices scoring | Weekly |
+| **Dependabot** | Automated dependency updates | Weekly |
 
-To prepare a new release with the database artifact:
+See [SECURITY.md](SECURITY.md) for the full policy and vulnerability reporting.
 
-```bash
-npm run prepare-release   # Creates data/database.db.gz
-gh release create v1.0.0
-gh release upload v1.0.0 data/database.db.gz
-npm publish
-```
-
-The gzipped database is uploaded to GitHub Releases. When users install via `npx`, the database is automatically downloaded and cached on first run.
-
-## Directory Review Notes
-
-### Testing Account and Sample Data
-
-This server is read-only and does not require a login account for functional review.
-For directory review, use the bundled dataset and these sample prompts:
-
-- _"Search Dutch legislation for persoonsgegevens verwerking"_
-- _"Get BWBR0005289 provision 6:162"_
-- _"Which Dutch statutes implement GDPR?"_
-
-### Remote Authentication (OAuth 2.0)
-
-When deployed over Streamable HTTP, this server can run in read-only unauthenticated mode.
-If authentication is required in your deployment, configure OAuth 2.0 over TLS with certificates from recognized authorities.
-
-### Privacy
-
-See [PRIVACY.md](PRIVACY.md) for data handling, retention, and security disclosures.
-
-### Troubleshooting
-
-- If startup fails, confirm the database path via `DUTCH_LAW_DB_PATH`.
-- If HTTP clients fail, verify `/mcp` POST routing and session headers.
-- If results are empty, call `list_regulations` first to confirm dataset load.
+---
 
 ## Important Disclaimers
 
@@ -328,84 +329,168 @@ See [PRIVACY.md](PRIVACY.md) for data handling, retention, and security disclosu
 
 > **THIS TOOL IS NOT LEGAL ADVICE**
 >
-> Statute text is sourced from official wetten.overheid.nl publications. However:
->
+> Statute text is sourced from official Wetten.overheid.nl publications. However:
 > - This is a **research tool**, not a substitute for professional legal counsel
 > - **Court case coverage is limited** -- do not rely solely on this for case law research
 > - **Verify critical citations** against primary sources for court filings
-> - **EU cross-references** are extracted from Dutch statute text, not EUR-Lex full text
+> - **EU cross-references** are extracted from Dutch statute text and EUR-Lex metadata, not full EU law text
+> - **Municipal and provincial legislation is not included** -- this covers national (rijks) legislation only
+
+**Before using professionally, read:** [DISCLAIMER.md](DISCLAIMER.md) | [PRIVACY.md](PRIVACY.md)
 
 ### Client Confidentiality
 
-Queries go through the Claude API. For privileged or confidential matters, use on-premise deployment. Lawyers should consider Nederlandse Orde van Advocaten (Dutch Bar Association) confidentiality obligations when using cloud-based AI tools.
+Queries go through the Claude API. For privileged or confidential matters (including attorney-client privilege under the Wet op de rechtsbijstand), use on-premise deployment. See [PRIVACY.md](PRIVACY.md) for guidance on use in Dutch legal practice.
+
+---
+
+## Documentation
+
+- **[EU Integration Guide](docs/EU_INTEGRATION_GUIDE.md)** -- Detailed EU cross-reference documentation
+- **[EU Usage Examples](docs/EU_USAGE_EXAMPLES.md)** -- Practical EU lookup examples
+- **[Security Policy](SECURITY.md)** -- Vulnerability reporting and scanning details
+- **[Disclaimer](DISCLAIMER.md)** -- Legal disclaimers and professional use notices
+- **[Privacy](PRIVACY.md)** -- Client confidentiality and data handling
+
+---
+
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/Ansvar-Systems/Dutch-law-mcp
+cd Dutch-law-mcp
+npm install
+npm run build
+npm test
+```
+
+### Running Locally
+
+```bash
+npm run dev                                       # Start MCP server (stdio)
+npm run dev:http                                  # Start HTTP server
+npx @anthropic/mcp-inspector node dist/index.js   # Test with MCP Inspector
+```
+
+### Data Management
+
+```bash
+npm run ingest                   # Ingest statutes from Wetten.overheid.nl BWB API
+npm run ingest:all               # Full corpus ingest
+npm run ingest:cases             # Ingest case law from Rechtspraak.nl
+npm run ingest:prep-works        # Ingest Kamerstukken and preparatory works
+npm run build:db                 # Rebuild free-tier SQLite database
+npm run build:db:paid            # Rebuild premium SQLite database
+npm run drift:detect             # Run drift detection against BWB anchors
+npm run check-updates            # Check for statute amendments
+npm run extract:definitions      # Extract legal definitions
+npm run populate:xrefs           # Populate EU cross-references
+```
+
+### Performance
+
+- **Search Speed:** <100ms for most FTS5 queries
+- **Database Size:** 134 MB (efficient, portable)
+- **Reliability:** 100% ingestion success rate
+
+---
 
 ## Related Projects: Complete Compliance Suite
 
 This server is part of **Ansvar's Compliance Suite** -- MCP servers that work together for end-to-end compliance coverage:
 
 ### [@ansvar/eu-regulations-mcp](https://github.com/Ansvar-Systems/EU_compliance_MCP)
-
 **Query 49 EU regulations directly from Claude** -- GDPR, AI Act, DORA, NIS2, MiFID II, eIDAS, and more. Full regulatory text with article-level search. `npx @ansvar/eu-regulations-mcp`
 
 ### @ansvar/dutch-law-mcp (This Project)
-
-**Query 3,248 Dutch statutes directly from Claude** -- BW, Sr, Awb, and more. Full provision text with EU cross-references. `npx @ansvar/dutch-law-mcp`
-
-### [@ansvar/german-law-mcp](https://github.com/Ansvar-Systems/German-law-mcp)
-
-**Query 6,870 German statutes directly from Claude** -- BGB, StGB, GG, and more. Full provision text with EU cross-references. `npx @ansvar/german-law-mcp`
-
-### [@ansvar/swedish-law-mcp](https://github.com/Ansvar-Systems/swedish-law-mcp)
-
-**Query 717 Swedish statutes directly from Claude** -- DSL, BrB, ABL, MB, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
-
-### [@ansvar/slovenian-law-mcp](https://github.com/Ansvar-Systems/Slovenian-law-mcp)
-
-**Query Slovenian statutes directly from Claude** -- ZVOP-2, KZ-1, ZGD-1, and more. Full provision text with EU cross-references. `npx @ansvar/slovenian-law-mcp`
+**Query 46 key Dutch statutes directly from Claude** -- AVG, BW, WvSr, Mededingingswet, Wft, and more. Full provision text with EU cross-references. `npx @ansvar/dutch-law-mcp`
 
 ### [@ansvar/us-regulations-mcp](https://github.com/Ansvar-Systems/US_Compliance_MCP)
-
 **Query US federal and state compliance laws** -- HIPAA, CCPA, SOX, GLBA, FERPA, and more. `npm install @ansvar/us-regulations-mcp`
 
 ### [@ansvar/ot-security-mcp](https://github.com/Ansvar-Systems/ot-security-mcp)
-
 **Query IEC 62443, NIST 800-82/53, and MITRE ATT&CK for ICS** -- Specialized for OT/ICS environments. `npx @ansvar/ot-security-mcp`
 
 ### [@ansvar/automotive-cybersecurity-mcp](https://github.com/Ansvar-Systems/Automotive-MCP)
-
 **Query UNECE R155/R156 and ISO 21434** -- Automotive cybersecurity compliance. `npx @ansvar/automotive-cybersecurity-mcp`
 
 ### [@ansvar/sanctions-mcp](https://github.com/Ansvar-Systems/Sanctions-MCP)
-
 **Offline-capable sanctions screening** -- OFAC, EU, UN sanctions lists. `pip install ansvar-sanctions-mcp`
+
+**70+ national law MCPs** covering Australia, Belgium, Brazil, Canada, Denmark, Finland, France, Germany, Ireland, Italy, Japan, Norway, Poland, Singapore, South Korea, Sweden, Switzerland, UK, and more.
+
+---
+
+## Contributing
+
+Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+Priority areas:
+- Court case law expansion (Hoge Raad, Gerechtshoven archive)
+- EU Regulations MCP integration (full EU law text, CJEU case law)
+- Historical statute versions and amendment tracking
+- Lower court decisions (Rechtbanken archives)
+- English translations for key statutes
+
+---
+
+## Roadmap
+
+- [x] **Core statute database** -- 46 key Dutch statutes with FTS5 search
+- [x] **EU law integration** -- cross-references to EU directives and regulations
+- [x] **Premium case law** -- 59,261 Hoge Raad and Gerechtshoven rulings
+- [x] **Premium preparatory works** -- 2,994 Kamerstukken documents
+- [x] **Vercel Streamable HTTP deployment**
+- [x] **npm package publication**
+- [ ] Statute corpus expansion (full Wetten.overheid.nl coverage)
+- [ ] Historical statute versions (amendment tracking)
+- [ ] Lower court coverage (Rechtbanken archives)
+- [ ] Full EU text integration (via @ansvar/eu-regulations-mcp)
+- [ ] English translations for key statutes
+- [ ] Web API for programmatic access
+
+---
 
 ## Citation
 
 If you use this MCP server in academic research:
 
 ```bibtex
-@software{dutch_law_mcp_2025,
+@software{dutch_law_mcp_2026,
   author = {Ansvar Systems AB},
   title = {Dutch Law MCP Server: Production-Grade Legal Research Tool},
-  year = {2025},
+  year = {2026},
   url = {https://github.com/Ansvar-Systems/Dutch-law-mcp},
-  note = {Comprehensive Dutch legal database with 3,248 statutes, 903,000+ court decisions, and EU cross-references}
+  note = {46 key Dutch statutes with 13,815 provisions and EU law cross-references}
 }
 ```
 
+---
+
 ## License
 
-Apache-2.0
+Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Regulations:** wetten.overheid.nl (public domain, Dutch government open data)
-- **Case Law:** rechtspraak.nl (public domain, open data portal)
-- **Kamerstukken:** Staten-Generaal (public domain)
+- **Statutes & Legislation:** Ministerie van Justitie en Veiligheid ([Open Government License -- Netherlands](https://data.overheid.nl/en/open-government-licence-netherlands))
+- **Case Law:** Rechtspraak.nl open data
 - **EU Metadata:** EUR-Lex (EU public domain)
+
+---
 
 ## About Ansvar Systems
 
-We build AI-accelerated compliance and legal research tools for the European market. This MCP server is part of our growing suite of jurisdiction-specific legal research tools.
+We build AI-accelerated compliance and legal research tools for the European market. This MCP server started as our internal reference tool for Dutch law -- turns out everyone building for the Dutch and EU market has the same research frustrations.
+
+So we're open-sourcing it. Navigating 46 statutes and 13,815 provisions shouldn't require a law degree.
 
 **[ansvar.eu](https://ansvar.eu)** -- Stockholm, Sweden
+
+---
+
+<p align="center">
+  <sub>Built with care in Stockholm, Sweden</sub>
+</p>


### PR DESCRIPTION
## Summary

- Replaces the existing README with a golden-standard README following the Law MCP Golden Standard format
- Tailored for Dutch jurisdiction: Wetten.overheid.nl source, 46 statutes, 13,815 provisions, 134 MB DB
- Includes EU integration section (NL is full EU member; AVG/GDPR, Mededingingswet, Telecommunicatiewet coverage)
- Documents premium tier: 59,261 case law rulings (Hoge Raad, Gerechtshoven) + 2,994 preparatory works (Kamerstukken)
- Example queries in Dutch and English

## Test plan

- [ ] Verify all badge URLs resolve (npm, CI, daily check)
- [ ] Verify endpoint URL `https://dutch-law-mcp.vercel.app/mcp` is live
- [ ] Confirm tool names match `src/index.ts` tool definitions
- [ ] Confirm `npx @ansvar/dutch-law-mcp` installs and starts cleanly
- [ ] Verify data provenance table matches actual ingest config

🤖 Generated with [Claude Code](https://claude.com/claude-code)