### PR TITLE
fix: remove broken legal_documents JOIN from case law search

### DIFF
--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -37,11 +37,16 @@ function clampLimit(limit: number | undefined): number {
   return Math.max(1, Math.min(limit, MAX_LIMIT));
 }
 
+function ecliToUrl(ecli: string | null): string | null {
+  if (ecli) return `https://uitspraken.rechtspraak.nl/details?id=${encodeURIComponent(ecli)}`;
+  return null;
+}
+
 function lookupByEcli(db: Database, ecli: string): SearchCaseLawResult[] {
   const sql = `
     SELECT
       cl.document_id,
-      d.title AS document_title,
+      cl.case_number AS document_title,
       cl.ecli,
       cl.court,
       cl.case_number,
@@ -50,13 +55,12 @@ function lookupByEcli(db: Database, ecli: string): SearchCaseLawResult[] {
       cl.legal_domain,
       cl.summary,
       NULL AS snippet,
-      NULL AS relevance,
-      d.url
+      NULL AS relevance
     FROM case_law AS cl
-    JOIN legal_documents AS d ON cl.document_id = d.id
     WHERE cl.ecli = ?
   `;
-  return db.prepare(sql).all(ecli) as SearchCaseLawResult[];
+  const rows = db.prepare(sql).all(ecli) as SearchCaseLawResult[];
+  return rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) }));
 }
 
 function runFtsSearch(
@@ -105,7 +109,7 @@ function runFtsSearch(
   const sql = `
     SELECT
       cl.document_id,
-      d.title AS document_title,
+      cl.case_number AS document_title,
       cl.ecli,
       cl.court,
       cl.case_number,
@@ -114,18 +118,17 @@ function runFtsSearch(
       cl.legal_domain,
       cl.summary,
       snippet(case_law_fts, 0, '**', '**', '...', 32) AS snippet,
-      bm25(case_law_fts) AS relevance,
-      d.url
+      bm25(case_law_fts) AS relevance
     FROM case_law_fts
     JOIN case_law AS cl ON case_law_fts.rowid = cl.id
-    JOIN legal_documents AS d ON cl.document_id = d.id
     ${whereClause}
     ORDER BY bm25(case_law_fts)
     LIMIT ?
   `;
   params.push(limit);
 
-  return db.prepare(sql).all(...params) as SearchCaseLawResult[];
+  const rows = db.prepare(sql).all(...params) as SearchCaseLawResult[];
+  return rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) }));
 }
 
 export async function searchCaseLaw(
@@ -158,10 +161,28 @@ export async function searchCaseLaw(
     return { results: [], _metadata: generateResponseMetadata(db) };
   }
 
-  let results = runFtsSearch(db, variants.primary, court, legal_domain, procedure_type, date_from, date_to, limit);
+  let results = runFtsSearch(
+    db,
+    variants.primary,
+    court,
+    legal_domain,
+    procedure_type,
+    date_from,
+    date_to,
+    limit,
+  );
 
   if (results.length === 0 && variants.fallback) {
-    results = runFtsSearch(db, variants.fallback, court, legal_domain, procedure_type, date_from, date_to, limit);
+    results = runFtsSearch(
+      db,
+      variants.fallback,
+      court,
+      legal_domain,
+      procedure_type,
+      date_from,
+      date_to,
+      limit,
+    );
   }
 
   return { results, _metadata: generateResponseMetadata(db) };


### PR DESCRIPTION
## Summary
- Removed the `JOIN legal_documents AS d ON cl.document_id = d.id` from both `lookupByEcli` and `runFtsSearch` functions
- **Root cause:** `case_law.document_id` contains ECLI identifiers (e.g. `ECLI:NL:HR:2013:BY4196`) while `legal_documents.id` contains BWB identifiers (e.g. `BWBR0001821`). The JOIN always returned 0 rows — every case law search returned empty results.
- Replaced `d.title` with `cl.case_number` for the `document_title` field
- Added `ecliToUrl()` helper that constructs `rechtspraak.nl` deep links from ECLI identifiers
- 59,261 case law records are now searchable (was 0 for every query)

## Test plan
- [x] Hot-patched on prod — verified `search_case_law` with query "persoonsgegevens" returns 10 results
- [x] Verified rechtspraak.nl URL generation (e.g. `https://uitspraken.rechtspraak.nl/details?id=ECLI%3ANL%3AHR%3A2013%3ABY4196`)
- [x] Lint + prettier pass
- [ ] Merge to main → GHCR build → Watchtower auto-update

🤖 Generated with [Claude Code](https://claude.com/claude-code)