### PR TITLE
fix: address fleet audit findings (CI, about/freshness tools, monthly-rebuild)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC
 

--- a/.github/workflows/monthly-rebuild.yml
+++ b/.github/workflows/monthly-rebuild.yml
@@ -1,0 +1,75 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# MONTHLY DATABASE REBUILD WORKFLOW
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Triggers a full database rebuild on the first Monday of each month.
+# This ensures the bundled database stays current with upstream sources
+# (wetten.overheid.nl, rechtspraak.nl, EUR-Lex) even between releases.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+
+name: Monthly Rebuild
+
+on:
+  schedule:
+    # First day of each month at 02:00 UTC
+    - cron: '0 2 1 * *'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Database tier to rebuild'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - free
+          - paid
+
+concurrency:
+  group: monthly-rebuild
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Build free-tier database
+        if: ${{ github.event.inputs.tier == 'all' || github.event.inputs.tier == 'free' || github.event_name == 'schedule' }}
+        run: npm run build:db:free
+
+      - name: Build paid-tier database
+        if: ${{ github.event.inputs.tier == 'all' || github.event.inputs.tier == 'paid' || github.event_name == 'schedule' }}
+        run: npm run build:db:paid
+
+      - name: Run tests against rebuilt database
+        run: npm test
+
+      - name: Upload rebuilt databases as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rebuilt-databases-${{ github.run_id }}
+          path: |
+            data/database.db
+            data/database-free.db
+          retention-days: 7

--- a/src/tools/about.ts
+++ b/src/tools/about.ts
@@ -1,0 +1,66 @@
+/**
+ * about — Return server identity, version, data sources, and runtime capabilities.
+ *
+ * Exposes the same provenance information available via the MCP resource
+ * `case-law-stats://dutch-law-mcp/metadata` as a directly callable tool,
+ * so agents that prefer tool calls over resource reads can access it.
+ */
+
+import type Database from '@ansvar/mcp-sqlite';
+import { detectCapabilities, readDbMetadata } from '../capabilities.js';
+import { SERVER_NAME, SERVER_VERSION } from '../version.js';
+
+export interface AboutInput {
+  // No required inputs — tool returns static + runtime info.
+}
+
+export async function about(
+  db: InstanceType<typeof Database>,
+  _input: AboutInput,
+): Promise<{
+  name: string;
+  version: string;
+  description: string;
+  sources: Record<string, { name: string; url: string; license: string; description: string }>;
+  capabilities: string[];
+  tier: string;
+  db_built_at: string;
+  attribution: string;
+  _metadata: { tool: string };
+}> {
+  const caps = detectCapabilities(db);
+  const dbMeta = readDbMetadata(db);
+
+  return {
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+    description:
+      'Dutch Law MCP provides structured access to Dutch statutes (wetten.overheid.nl), court decisions (rechtspraak.nl), and EU legal references (EUR-Lex) via the Model Context Protocol.',
+    sources: {
+      statutes: {
+        name: 'Wetten.overheid.nl',
+        url: 'https://wetten.overheid.nl',
+        license: 'Government Open Data (CC0)',
+        description: 'Official BWB (Basiswettenbestand) for all consolidated Dutch statutes and regulations',
+      },
+      case_law: {
+        name: 'Rechtspraak.nl',
+        url: 'https://uitspraken.rechtspraak.nl',
+        license: 'Open Justice Data',
+        description: 'Published court decisions from all Dutch courts',
+      },
+      eu_law: {
+        name: 'EUR-Lex',
+        url: 'https://eur-lex.europa.eu',
+        license: 'EU Open Data (Decision 2011/833/EU)',
+        description: 'EU directives and regulations referenced by Dutch statutes (metadata only)',
+      },
+    },
+    capabilities: [...caps],
+    tier: dbMeta.tier,
+    db_built_at: dbMeta.built_at,
+    attribution:
+      'Data sourced from wetten.overheid.nl and rechtspraak.nl under open data licenses. EU law metadata from EUR-Lex.',
+    _metadata: { tool: 'about' },
+  };
+}

--- a/src/tools/check-data-freshness.ts
+++ b/src/tools/check-data-freshness.ts
@@ -1,0 +1,110 @@
+/**
+ * check_data_freshness — Report the age and freshness of each data source in the database.
+ *
+ * Freshness information is stored per-source in the db_metadata table and embedded
+ * in every tool response's _metadata block, but this dedicated tool makes it
+ * directly callable so agents can check data currency before relying on results.
+ */
+
+import type Database from '@ansvar/mcp-sqlite';
+
+export interface CheckDataFreshnessInput {
+  source?: 'statutes' | 'case_law' | 'eu_references';
+}
+
+interface SourceFreshness {
+  source: string;
+  last_updated: string;
+  age_days: number | null;
+  status: 'fresh' | 'stale' | 'unknown';
+  threshold_days: number;
+}
+
+// Consider a source stale if not updated within this many days.
+const STALENESS_THRESHOLDS: Record<string, number> = {
+  statutes: 30,
+  case_law: 14,
+  eu_references: 90,
+};
+
+export async function checkDataFreshness(
+  db: InstanceType<typeof Database>,
+  input: CheckDataFreshnessInput,
+): Promise<{
+  overall_status: 'fresh' | 'stale' | 'unknown';
+  sources: SourceFreshness[];
+  checked_at: string;
+  _metadata: { tool: string };
+}> {
+  const checkedAt = new Date().toISOString();
+  const sourcesToCheck = input.source ? [input.source] : ['statutes', 'case_law', 'eu_references'];
+
+  const freshnessList: SourceFreshness[] = sourcesToCheck.map((source) => {
+    const lastUpdated = getSourceLastUpdated(db, source);
+    const threshold = STALENESS_THRESHOLDS[source] ?? 30;
+    const ageDays = computeAgeDays(lastUpdated);
+
+    let status: 'fresh' | 'stale' | 'unknown';
+    if (ageDays === null) {
+      status = 'unknown';
+    } else if (ageDays > threshold) {
+      status = 'stale';
+    } else {
+      status = 'fresh';
+    }
+
+    return { source, last_updated: lastUpdated ?? 'unknown', age_days: ageDays, status, threshold_days: threshold };
+  });
+
+  const statuses = freshnessList.map((f) => f.status);
+  let overallStatus: 'fresh' | 'stale' | 'unknown';
+  if (statuses.includes('stale')) {
+    overallStatus = 'stale';
+  } else if (statuses.every((s) => s === 'unknown')) {
+    overallStatus = 'unknown';
+  } else {
+    overallStatus = 'fresh';
+  }
+
+  return {
+    overall_status: overallStatus,
+    sources: freshnessList,
+    checked_at: checkedAt,
+    _metadata: { tool: 'check_data_freshness' },
+  };
+}
+
+function getSourceLastUpdated(
+  db: InstanceType<typeof Database>,
+  source: string,
+): string | undefined {
+  // Keys written by the database builder follow the pattern `<source>_last_updated`
+  // with a fallback to the generic `last_updated` key.
+  const sourceKey = `${source}_last_updated`;
+  try {
+    const row = db
+      .prepare('SELECT value FROM db_metadata WHERE key = ?')
+      .get(sourceKey) as { value: string } | undefined;
+    if (row?.value) return row.value;
+
+    // Generic fallback
+    const fallback = db
+      .prepare("SELECT value FROM db_metadata WHERE key = 'last_updated'")
+      .get() as { value: string } | undefined;
+    return fallback?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+function computeAgeDays(dateStr: string | undefined): number | null {
+  if (!dateStr || dateStr === 'unknown') return null;
+  try {
+    const then = new Date(dateStr).getTime();
+    if (isNaN(then)) return null;
+    const now = Date.now();
+    return Math.floor((now - then) / (1000 * 60 * 60 * 24));
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -31,6 +31,8 @@ import { getProvisionEUBasis, type GetProvisionEUBasisInput } from './get-provis
 import { validateEUCompliance, type ValidateEUComplianceInput } from './validate-eu-compliance.js';
 import { getProvisionAtDate, type GetProvisionAtDateInput } from './get-provision-at-date.js';
 import { listSources, type ListSourcesInput } from './list-sources.js';
+import { about, type AboutInput } from './about.js';
+import { checkDataFreshness, type CheckDataFreshnessInput } from './check-data-freshness.js';
 import { validateInput, COMMON_FIELDS } from '../utils/validate-input.js';
 
 const READ_ONLY_ANNOTATIONS = {
@@ -375,6 +377,32 @@ export const TOOLS: Tool[] = [
       required: [],
     },
   },
+  {
+    name: 'about',
+    description:
+      'Return server identity, version, data sources, and runtime capabilities. Use this tool to discover what tier and capabilities are available (free vs professional), which data sources are bundled, and the server version. Equivalent to reading the MCP resource `case-law-stats://dutch-law-mcp/metadata` but callable as a tool.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'check_data_freshness',
+    description:
+      'Check the freshness (age) of each data source in the bundled database. Returns last-updated timestamps and a fresh/stale/unknown status per source (statutes, case_law, eu_references). Use this before relying on legal data for time-sensitive analysis. Staleness thresholds: statutes 30 days, case_law 14 days, eu_references 90 days.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        source: {
+          type: 'string',
+          description: 'Limit check to a single source. Omit to check all sources.',
+          enum: ['statutes', 'case_law', 'eu_references'],
+        },
+      },
+      required: [],
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -480,6 +508,12 @@ export function registerTools(server: Server, getDb: () => InstanceType<typeof D
           break;
         case 'list_sources':
           result = await listSources(getDb(), a as unknown as ListSourcesInput);
+          break;
+        case 'about':
+          result = await about(getDb(), a as unknown as AboutInput);
+          break;
+        case 'check_data_freshness':
+          result = await checkDataFreshness(getDb(), a as unknown as CheckDataFreshnessInput);
           break;
         default:
           return {


### PR DESCRIPTION
## Summary

Fleet continuous improvement audit identified four fixable items — all addressed in this PR:

- **CI `dev` branch gap**: `pull_request.branches` only listed `main`, so PRs targeting `dev` never triggered CI. Added `- dev` to fix the branching strategy.
- **`about` tool**: Golden-standard requires a callable tool (not just an MCP resource). Added `src/tools/about.ts` exposing server identity, version, tier, capabilities, and data sources.
- **`check_data_freshness` tool**: Added `src/tools/check-data-freshness.ts` — checks age and freshness status per source (statutes / case_law / eu_references) with configurable staleness thresholds.
- **`monthly-rebuild.yml`**: Added scheduled workflow (1st of each month, 02:00 UTC) for full database rebuild, plus `workflow_dispatch` for manual tier-specific rebuilds.

## Not addressed

- **`tieredFtsSearch`**: The audit flagged that the repo uses its own FTS query builder (`src/utils/fts-query.ts`) rather than a fleet utility. This requires a manual decision on whether to adopt the fleet utility — skipped to avoid breaking existing search behaviour.

## Test plan

- [ ] TypeScript build passes (`npm run build`)
- [ ] `about` tool returns server name, version, tier, and capabilities
- [ ] `check_data_freshness` tool returns freshness status for all three sources
- [ ] CI run triggers on a PR targeting `dev`
- [ ] `monthly-rebuild.yml` appears in Actions and can be triggered via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)