### PR TITLE
fix: upgrade trivy-action 0.34.0 → 0.35.0 (CVE-2026-33634, SLA breached)

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -43,7 +43,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: dutch-law-mcp:scan
           format: 'sarif'
@@ -61,7 +61,7 @@ jobs:
           category: 'trivy-container'
 
       - name: Run Trivy for JSON report (audit evidence)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: dutch-law-mcp:scan
           format: 'json'
@@ -70,7 +70,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Run Trivy for table output (summary)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: dutch-law-mcp:scan
           format: 'table'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -39,7 +39,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy for npm dependencies
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary
- Upgrades `aquasecurity/trivy-action` from `0.34.0` to `0.35.0` in `trivy.yml` and `docker-security.yml`
- Fixes GHSA-69fq-xp46-6x23 / CVE-2026-33634: Trivy ecosystem supply chain was briefly compromised
- **SLA breached**: critical severity, created 2026-03-24, 7-day SLA expired 2026-03-31

## Test plan
- [ ] CI passes on this branch
- [ ] Verify Dependabot alerts #38 and #39 are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)