### PR TITLE
fix: upgrade Dockerfile node:22-alpine → node:24-alpine (CVE-2026-21710)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ===================================
 # Stage 1: Builder
 # ===================================
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache python3 make g++
@@ -26,7 +26,7 @@ RUN npm run build
 # ===================================
 # Stage 2: Production
 # ===================================
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 
 # Metadata labels (OCI standard)
 LABEL org.opencontainers.image.title="Dutch Law MCP Server"


### PR DESCRIPTION
## Summary
- Upgrades Docker base image from `node:22-alpine` to `node:24-alpine` in both build stages
- Fixes CVE-2026-21710 (high, CWE-770) — no patched release exists for Node.js 22.x
- Also resolves CVE-2026-21713/21714/21715/21716/21717 (medium/low) flagged by Aikido container scan

Patched versions per advisory: 20.20.2, 24.14.1, 25.8.2 — Node.js 22 is unpatched.
Major version upgrade justified by high-severity CVE per ADR-003 policy.

`package.json` engines field (`>=18`) is compatible with Node.js 24.

## Test plan
- [ ] Docker image builds successfully
- [ ] Aikido container scan shows Node.js CVEs resolved
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)