### PR TITLE
fix: repair Trivy + Semgrep scan workflows

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   semgrep:
@@ -36,7 +37,8 @@ jobs:
             --metrics=off
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   scan:
@@ -23,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -33,13 +34,14 @@ jobs:
           ignore-unfixed: false
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy for npm dependencies
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

Fleet-wide fix for broken security scan workflows:

- **Trivy**: upgrade `aquasecurity/trivy-action` to `v0.35.0` (fix missing `v` prefix tag resolution)
- **codeql-action**: upgrade `upload-sarif` from `v3` to `v4` (v3 deprecated Dec 2026)
- **Permissions**: add `actions: read` (required by codeql-action for workflow API access)
- **SARIF upload**: add `continue-on-error: true` (scan succeeds even if Code Scanning is not enabled)

These are CI-only changes — no runtime code affected.