### PR TITLE
feat(stopwords): add kamer, deze, heeft to Dutch legal stopword list

### DIFF
--- a/src/utils/fts-query.ts
+++ b/src/utils/fts-query.ts
@@ -49,11 +49,15 @@ const DUTCH_LEGAL_STOPWORDS = new Set([
   'kan',
   'moet',
   'zal',
+  'deze',
+  'heeft',
   // ubiquitous legal terms that match the entire corpus
   'wet',
   'art',
   'lid',
   'nr',
+  // parliamentary-corpus specific — matches every Tweede Kamer proceeding
+  'kamer',
 ]);
 
 function sanitizeToken(token: string): string {

--- a/tests/utils/fts-stopwords.test.ts
+++ b/tests/utils/fts-stopwords.test.ts
@@ -19,6 +19,17 @@ describe('Dutch legal stopword filtering', () => {
       expect(DUTCH_LEGAL_STOPWORDS.has('lid')).toBe(true);
     });
 
+    it('should contain common auxiliary verbs and demonstratives', () => {
+      expect(DUTCH_LEGAL_STOPWORDS.has('deze')).toBe(true);
+      expect(DUTCH_LEGAL_STOPWORDS.has('heeft')).toBe(true);
+      expect(DUTCH_LEGAL_STOPWORDS.has('worden')).toBe(true);
+    });
+
+    it('should contain parliamentary-corpus specific terms', () => {
+      // "kamer" appears in every Tweede Kamer proceeding — broad match hazard
+      expect(DUTCH_LEGAL_STOPWORDS.has('kamer')).toBe(true);
+    });
+
     it('should NOT contain substantive legal terms', () => {
       expect(DUTCH_LEGAL_STOPWORDS.has('onrechtmatige')).toBe(false);
       expect(DUTCH_LEGAL_STOPWORDS.has('persoonsgegevens')).toBe(false);


### PR DESCRIPTION
## Summary

Follow-up to #53. Proactively expand the Dutch legal stopword list based on corpus analysis of the newly-exposed parliamentary proceedings data.

## Additions

- **`kamer`** — appears in every single Tweede Kamer proceeding record (596K rows, all from the House of Representatives). A bare `{"query": "kamer"}` would be as slow as `{"query": "wet"}`, which is exactly what the stopword filter was built to prevent.
- **`deze`** (this/these) — extremely common Dutch demonstrative with no discriminative value on its own.
- **`heeft`** (has) — auxiliary verb, ubiquitous in legal and parliamentary text.

`worden` was already in the first-pass list, not re-added.

## Why proactive

The first-pass list was built from observed pathological queries in the slow-query log (`wet`, `art`, `lid`, `nr` dominated). These three additions are extrapolation from corpus structure, not observed pain — the reasoning is that once `search_parliamentary_proceedings` is live, users will naturally form queries like "kamer debat" or "de kamer heeft", and we'd rather block the pathological cases now than wait for them to show up in Tempo traces.

## Test plan

- [x] 2 new tests verify additions are present in `DUTCH_LEGAL_STOPWORDS`
- [x] Full suite: 310 passed (was 308)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint 'src/**/*.ts' 'tests/**/*.ts'` clean

## Related

- #53 — parliamentary proceedings tool + initial stopword list
- #55 — tracking issue for consolidating the law MCP update path

🤖 Generated with [Claude Code](https://claude.com/claude-code)