### PR TITLE
fix: populate Dutch search citation metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1821,9 +1821,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "@types/node": "^22.15.29",
-        "@vercel/node": "^5.6.3",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.27.0",
         "fast-xml-parser": "^5.3.5",
@@ -106,66 +105,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@bytecodealliance/preview2-shim": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.6.tgz",
-      "integrity": "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==",
-      "dev": true,
-      "license": "(Apache-2.0 WITH LLVM-exception)"
-    },
-    "node_modules/@edge-runtime/format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
-      "integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/node-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
-      "integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/ponyfill": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
-      "integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/primitives": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
-      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/vm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
-      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@edge-runtime/primitives": "4.1.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -778,16 +717,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -852,42 +781,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -914,28 +807,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
-      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "consola": "^3.2.3",
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^2.6.7",
-        "nopt": "^8.0.0",
-        "semver": "^7.5.3",
-        "tar": "^7.4.0"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -977,85 +848,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@renovatebot/pep440": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@renovatebot/pep440/-/pep440-4.2.1.tgz",
-      "integrity": "sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.9.0 || ^22.11.0 || ^24",
-        "pnpm": "^10.0.0"
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1414,19 +1206,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ts-morph/common": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
-      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.2.7",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "path-browserify": "^1.0.1"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1725,706 +1504,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@vercel/build-utils": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.14.0.tgz",
-      "integrity": "sha512-mEYh+f+sNngEOJKLTTzoyPMse5A3bQNt0uIRq/jfl/h12ukWhrpHDmXdY6k6x3WsEXr7hrcN+2jT0VdvOBgACw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vercel/python-analysis": "0.11.0",
-        "cjs-module-lexer": "1.2.3",
-        "es-module-lexer": "1.5.0"
-      }
-    },
-    "node_modules/@vercel/build-utils/node_modules/es-module-lexer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
-      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/error-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.0.3.tgz",
-      "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@vercel/nft": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
-      "integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^2.0.0",
-        "@rollup/pluginutils": "^5.1.3",
-        "acorn": "^8.6.0",
-        "acorn-import-attributes": "^1.9.5",
-        "async-sema": "^3.1.1",
-        "bindings": "^1.4.0",
-        "estree-walker": "2.0.2",
-        "glob": "^13.0.0",
-        "graceful-fs": "^4.2.9",
-        "node-gyp-build": "^4.2.2",
-        "picomatch": "^4.0.2",
-        "resolve-from": "^5.0.0"
-      },
-      "bin": {
-        "nft": "out/cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@vercel/nft/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/node": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.2.tgz",
-      "integrity": "sha512-uX4l/f/0eu6ktDdUobHxUm3jkI85Ptbp08yMYFYJo9PAmsYJ5jJoU3eOS47XgkIXmQHGC+14UP1NN7Jh1bTkTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@edge-runtime/node-utils": "2.3.0",
-        "@edge-runtime/primitives": "4.1.0",
-        "@edge-runtime/vm": "3.2.0",
-        "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.14.0",
-        "@vercel/error-utils": "2.0.3",
-        "@vercel/nft": "1.5.0",
-        "@vercel/static-config": "3.2.0",
-        "async-listen": "3.0.0",
-        "cjs-module-lexer": "1.2.3",
-        "edge-runtime": "2.5.9",
-        "es-module-lexer": "1.4.1",
-        "esbuild": "0.27.0",
-        "etag": "1.8.1",
-        "mime-types": "2.1.35",
-        "node-fetch": "2.6.9",
-        "path-to-regexp": "6.1.0",
-        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
-        "ts-morph": "12.0.0",
-        "tsx": "4.21.0",
-        "typescript": "npm:typescript@5.9.3",
-        "undici": "5.28.4"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/@types/node": {
-      "version": "20.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
-      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/es-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/node/node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@vercel/node/node_modules/path-to-regexp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/node/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/python-analysis": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.0.tgz",
-      "integrity": "sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bytecodealliance/preview2-shim": "0.17.6",
-        "@renovatebot/pep440": "4.2.1",
-        "fs-extra": "11.1.1",
-        "js-yaml": "4.1.1",
-        "minimatch": "10.1.1",
-        "smol-toml": "1.5.2",
-        "zod": "3.22.4"
-      }
-    },
-    "node_modules/@vercel/python-analysis/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vercel/python-analysis/node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@vercel/static-config": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.2.0.tgz",
-      "integrity": "sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "8.6.3",
-        "json-schema-to-ts": "1.6.4",
-        "ts-morph": "12.0.0"
-      }
-    },
-    "node_modules/@vercel/static-config/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
@@ -2567,16 +1646,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2603,16 +1672,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2621,16 +1680,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2740,39 +1789,12 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "node_modules/async-listen": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
-      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/async-sema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
-      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -2897,23 +1919,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2946,13 +1951,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/code-block-writer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
-      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2998,16 +1996,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -3028,16 +2016,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/convert-hrtime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
-      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cookie": {
@@ -3122,16 +2100,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3145,47 +2113,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/edge-runtime": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
-      "integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@edge-runtime/format": "2.2.1",
-        "@edge-runtime/ponyfill": "2.4.2",
-        "@edge-runtime/vm": "3.2.0",
-        "async-listen": "3.0.1",
-        "mri": "1.2.0",
-        "picocolors": "1.0.0",
-        "pretty-ms": "7.0.1",
-        "signal-exit": "4.0.2",
-        "time-span": "4.0.0"
-      },
-      "bin": {
-        "edge-runtime": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/edge-runtime/node_modules/async-listen": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
-      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/edge-runtime/node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3622,36 +2549,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3719,16 +2616,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3759,13 +2646,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3857,21 +2737,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3959,24 +2824,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3988,45 +2835,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -4053,13 +2861,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4096,9 +2897,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4129,20 +2930,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -4384,17 +3171,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
-      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.6",
-        "ts-toolbelt": "^6.15.5"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4413,19 +3189,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4537,16 +3300,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4613,16 +3366,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
@@ -4703,52 +3446,6 @@
         "node": "*"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4803,60 +3500,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-sqlite3-wasm": {
       "version": "0.8.53",
       "resolved": "https://registry.npmjs.org/node-sqlite3-wasm/-/node-sqlite3-wasm-0.8.53.tgz",
       "integrity": "sha512-HPuGOPj3L+h3WSf0XikIXTDpsRxlVmzBC3RMgqi3yDg9CEbm/4Hw3rrDodeITqITjm07X4atWLlDMMI8KERMiQ==",
       "license": "MIT"
-    },
-    "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^3.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4990,16 +3638,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5008,13 +3646,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5051,23 +3682,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -5077,14 +3691,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/path-to-regexp-updated": {
-      "name": "path-to-regexp",
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5190,22 +3796,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5244,27 +3834,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5296,16 +3865,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -5346,17 +3905,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rfdc": {
@@ -5425,30 +3973,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safer-buffer": {
@@ -5621,19 +4145,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
@@ -5662,19 +4173,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {
@@ -5792,39 +4290,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/time-span": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
-      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5891,13 +4356,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -5910,24 +4368,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-morph": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
-      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ts-morph/common": "~0.11.0",
-        "code-block-writer": "^10.1.1"
-      }
-    },
-    "node_modules/ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -6014,35 +4454,12 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -6225,24 +4642,6 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6339,16 +4738,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "format:check": "prettier --check .",
     "prepare": "node -e \"try{require('husky')}catch(e){process.exit(0)}\" && husky || true",
     "prepublishOnly": "npm run build",
-    "postinstall": "test -d dist || npm run build || true"
+    "postinstall": "node -e \"const fs=require('fs');const cp=require('child_process');if(!fs.existsSync('dist')){try{cp.execFileSync(process.platform==='win32'?'npm.cmd':'npm',['run','build'],{stdio:'inherit'})}catch{}}\""
   },
   "dependencies": {
     "@ansvar/mcp-sqlite": "^1.0.0",

--- a/scripts/build-db.ts
+++ b/scripts/build-db.ts
@@ -434,6 +434,75 @@ function readSeedFiles(): SeedFile[] {
   return seeds;
 }
 
+function isBlank(value: string | undefined): boolean {
+  return value == null || value.trim() === '';
+}
+
+function validateCitationSeedFields(seeds: SeedFile[]): void {
+  const documentIds = new Set<string>();
+
+  for (const seed of seeds) {
+    for (const doc of seed.documents ?? []) {
+      if (isBlank(doc.id) || isBlank(doc.title)) {
+        throw new Error(
+          `Citation metadata requires non-empty document id and title: ${JSON.stringify(doc)}`,
+        );
+      }
+      documentIds.add(doc.id);
+    }
+  }
+
+  for (const seed of seeds) {
+    for (const provision of seed.provisions ?? []) {
+      if (
+        isBlank(provision.document_id) ||
+        isBlank(provision.provision_ref) ||
+        isBlank(provision.article)
+      ) {
+        throw new Error(
+          `Citation metadata requires non-empty provision document_id, provision_ref, and article: ${JSON.stringify(
+            provision,
+          )}`,
+        );
+      }
+      if (!documentIds.has(provision.document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for provision ${provision.document_id}:${provision.provision_ref}`,
+        );
+      }
+    }
+
+    for (const provision of seed.provision_versions ?? []) {
+      if (
+        isBlank(provision.document_id) ||
+        isBlank(provision.provision_ref) ||
+        isBlank(provision.article)
+      ) {
+        throw new Error(
+          `Citation metadata requires non-empty versioned provision document_id, provision_ref, and article: ${JSON.stringify(
+            provision,
+          )}`,
+        );
+      }
+      if (!documentIds.has(provision.document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for versioned provision ${provision.document_id}:${provision.provision_ref}`,
+        );
+      }
+    }
+
+    for (const caseLaw of seed.case_law ?? []) {
+      if (isBlank(caseLaw.document_id) || isBlank(caseLaw.ecli) || isBlank(caseLaw.court)) {
+        throw new Error(
+          `Citation metadata requires non-empty case law document_id, ecli, and court: ${JSON.stringify(
+            caseLaw,
+          )}`,
+        );
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -469,6 +538,7 @@ function main(): void {
   console.log();
   console.log('Reading seed files...');
   const seeds = readSeedFiles();
+  validateCitationSeedFields(seeds);
 
   if (seeds.length === 0) {
     console.log('No seed files found. Database created with empty schema.');

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -2,7 +2,7 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { resolveDocumentId } from '../utils/document-id.js';
-import { buildProvisionCitation } from '../utils/citation.js';
+import { buildProvisionCitation, withCitationAttribution } from '../utils/citation.js';
 
 export interface GetProvisionInput {
   document_id: string;
@@ -24,6 +24,8 @@ export interface GetProvisionResult {
   article: string;
   title: string | null;
   content: string;
+  source_url: string | null;
+  effective_date: string | null;
   valid_from?: string | null;
   valid_to?: string | null;
 }
@@ -52,7 +54,9 @@ function getCurrentProvisions(
         p.section,
         p.article,
         p.title,
-        p.content
+        p.content,
+        COALESCE(d.url, 'https://wetten.overheid.nl/' || p.document_id) AS source_url,
+        d.in_force_date AS effective_date
       FROM legal_provisions AS p
       JOIN legal_documents AS d ON p.document_id = d.id
       WHERE p.document_id = ? AND p.provision_ref = ?
@@ -72,7 +76,9 @@ function getCurrentProvisions(
       p.section,
       p.article,
       p.title,
-      p.content
+      p.content,
+      COALESCE(d.url, 'https://wetten.overheid.nl/' || p.document_id) AS source_url,
+      d.in_force_date AS effective_date
     FROM legal_provisions AS p
     JOIN legal_documents AS d ON p.document_id = d.id
     WHERE p.document_id = ?
@@ -111,6 +117,8 @@ function getVersionedProvisions(
       pv.article,
       pv.title,
       pv.content,
+      COALESCE(d.url, 'https://wetten.overheid.nl/' || pv.document_id) AS source_url,
+      COALESCE(pv.valid_from, d.in_force_date) AS effective_date,
       pv.valid_from,
       pv.valid_to
     FROM legal_provision_versions AS pv
@@ -139,14 +147,24 @@ export async function getProvision(
     results,
     ...(provisionRef &&
       firstResult && {
-        _citation: buildProvisionCitation(
-          firstResult.document_id,
-          firstResult.document_title || '',
-          firstResult.provision_ref || '',
-          input.document_id,
-          input.section || input.provision_ref || input.article || '',
-          null,
-          null,
+        _citation: withCitationAttribution(
+          buildProvisionCitation(
+            firstResult.document_id,
+            firstResult.document_title || '',
+            firstResult.provision_ref || '',
+            input.document_id,
+            input.section || input.provision_ref || input.article || '',
+            firstResult.source_url,
+            null,
+          ),
+          {
+            jurisdiction: 'NL',
+            source: firstResult.document_title,
+            article: firstResult.article || firstResult.provision_ref,
+            publisher: 'Dutch Government (wetten.overheid.nl)',
+            license: 'Dutch government open data',
+            effective_date: firstResult.effective_date || firstResult.valid_from || null,
+          },
         ),
       }),
     _metadata: generateResponseMetadata(db),

--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -2,6 +2,11 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariants } from '../utils/fts-query.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { hasTable } from '../capabilities.js';
+import {
+  buildCitation,
+  withCitationAttribution,
+  type CitationMetadata,
+} from '../utils/citation.js';
 
 export interface SearchCaseLawInput {
   query: string;
@@ -27,6 +32,7 @@ export interface SearchCaseLawResult {
   snippet: string | null;
   relevance: number | null;
   url: string | null;
+  _citation?: CitationMetadata;
 }
 
 const MAX_LIMIT = 50;
@@ -40,6 +46,35 @@ function clampLimit(limit: number | undefined): number {
 function ecliToUrl(ecli: string | null): string | null {
   if (ecli) return `https://uitspraken.rechtspraak.nl/details?id=${encodeURIComponent(ecli)}`;
   return null;
+}
+
+function addResultCitations(rows: SearchCaseLawResult[]): SearchCaseLawResult[] {
+  return rows.map((row) => {
+    const canonicalRef = row.ecli || row.document_id;
+    const displayText = [row.court, row.decision_date, canonicalRef].filter(Boolean).join(' ');
+    const citation = buildCitation(
+      canonicalRef,
+      displayText,
+      'search_case_law',
+      { ecli: canonicalRef },
+      row.url || ecliToUrl(row.ecli),
+      [row.document_id, row.case_number, row.document_title].filter((value): value is string =>
+        Boolean(value),
+      ),
+    );
+
+    return {
+      ...row,
+      _citation: withCitationAttribution(citation, {
+        jurisdiction: 'NL',
+        source: row.court || 'rechtspraak.nl',
+        article: canonicalRef,
+        publisher: 'De Rechtspraak (Dutch Judiciary)',
+        license: 'Open justice data',
+        effective_date: row.decision_date,
+      }),
+    };
+  });
 }
 
 function lookupByEcli(db: Database, ecli: string): SearchCaseLawResult[] {
@@ -60,7 +95,7 @@ function lookupByEcli(db: Database, ecli: string): SearchCaseLawResult[] {
     WHERE cl.ecli = ?
   `;
   const rows = db.prepare(sql).all(ecli) as SearchCaseLawResult[];
-  return rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) }));
+  return addResultCitations(rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) })));
 }
 
 function runFtsSearch(
@@ -128,7 +163,7 @@ function runFtsSearch(
   params.push(limit);
 
   const rows = db.prepare(sql).all(...params) as SearchCaseLawResult[];
-  return rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) }));
+  return addResultCitations(rows.map((r) => ({ ...r, url: ecliToUrl(r.ecli) })));
 }
 
 export async function searchCaseLaw(

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -4,6 +4,11 @@ import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { resolveDocumentId } from '../utils/document-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { withSqliteLockRetry } from '../utils/sqlite-retry.js';
+import {
+  buildProvisionCitation,
+  withCitationAttribution,
+  type CitationMetadata,
+} from '../utils/citation.js';
 
 export interface SearchLegislationInput {
   query: string;
@@ -20,11 +25,15 @@ export interface SearchLegislationResult {
   book: string | null;
   chapter: string | null;
   section: string | null;
+  article: string;
   title: string | null;
   snippet: string;
   relevance: number;
+  source_url: string | null;
+  effective_date: string | null;
   valid_from?: string | null;
   valid_to?: string | null;
+  _citation?: CitationMetadata;
 }
 
 const MAX_LIMIT = 50;
@@ -68,9 +77,12 @@ function runFtsSearch(
       p.book,
       p.chapter,
       p.section,
+      p.article,
       p.title,
       snippet(provisions_fts, 0, '**', '**', '...', 32) AS snippet,
-      bm25(provisions_fts) AS relevance
+      bm25(provisions_fts) AS relevance,
+      COALESCE(d.url, 'https://wetten.overheid.nl/' || p.document_id) AS source_url,
+      d.in_force_date AS effective_date
     FROM provisions_fts
     JOIN legal_provisions AS p ON provisions_fts.rowid = p.id
     JOIN legal_documents AS d ON p.document_id = d.id
@@ -123,9 +135,12 @@ function runVersionedFtsSearch(
       pv.book,
       pv.chapter,
       pv.section,
+      pv.article,
       pv.title,
       snippet(provision_versions_fts, 0, '**', '**', '...', 32) AS snippet,
       bm25(provision_versions_fts) AS relevance,
+      COALESCE(d.url, 'https://wetten.overheid.nl/' || pv.document_id) AS source_url,
+      COALESCE(pv.valid_from, d.in_force_date) AS effective_date,
       pv.valid_from,
       pv.valid_to
     FROM provision_versions_fts
@@ -158,6 +173,32 @@ function deduplicateResults(
     if (deduped.length >= limit) break;
   }
   return deduped;
+}
+
+function addResultCitations(rows: SearchLegislationResult[]): SearchLegislationResult[] {
+  return rows.map((row) => {
+    const citation = buildProvisionCitation(
+      row.document_id,
+      row.document_title || '',
+      row.provision_ref || row.article || '',
+      row.document_id,
+      row.provision_ref || row.article || '',
+      row.source_url,
+      null,
+    );
+
+    return {
+      ...row,
+      _citation: withCitationAttribution(citation, {
+        jurisdiction: 'NL',
+        source: row.document_title,
+        article: row.article || row.provision_ref,
+        publisher: 'Dutch Government (wetten.overheid.nl)',
+        license: 'Dutch government open data',
+        effective_date: row.effective_date || row.valid_from || null,
+      }),
+    };
+  });
 }
 
 export async function searchLegislation(
@@ -217,7 +258,7 @@ export async function searchLegislation(
     broadened = results.length > 0;
   }
 
-  const deduped = deduplicateResults(results, limit);
+  const deduped = addResultCitations(deduplicateResults(results, limit));
 
   return {
     results: deduped,

--- a/src/tools/search-parliamentary-proceedings.ts
+++ b/src/tools/search-parliamentary-proceedings.ts
@@ -2,6 +2,11 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariants } from '../utils/fts-query.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { hasTable } from '../capabilities.js';
+import {
+  buildCitation,
+  withCitationAttribution,
+  type CitationMetadata,
+} from '../utils/citation.js';
 
 export interface SearchParliamentaryProceedingsInput {
   query: string;
@@ -19,6 +24,7 @@ export interface SearchParliamentaryProceedingsResult {
   relevance: number | null;
   url: string | null;
   related_statute_id: string | null;
+  _citation?: CitationMetadata;
 }
 
 const MAX_LIMIT = 50;
@@ -75,6 +81,34 @@ function runFtsSearch(
   return db.prepare(sql).all(...params) as SearchParliamentaryProceedingsResult[];
 }
 
+function addResultCitations(
+  rows: SearchParliamentaryProceedingsResult[],
+): SearchParliamentaryProceedingsResult[] {
+  return rows.map((row) => {
+    const canonicalRef = `NL parliamentary proceeding ${row.id}`;
+    const citation = buildCitation(
+      canonicalRef,
+      row.title || canonicalRef,
+      'search_parliamentary_proceedings',
+      { query: row.title || canonicalRef },
+      row.url,
+      [row.related_statute_id].filter((value): value is string => Boolean(value)),
+    );
+
+    return {
+      ...row,
+      _citation: withCitationAttribution(citation, {
+        jurisdiction: 'NL',
+        source: row.title,
+        article: row.related_statute_id || canonicalRef,
+        publisher: 'Tweede Kamer / ParlaMint-NL',
+        license: 'Dutch parliamentary open data',
+        effective_date: row.issued_date,
+      }),
+    };
+  });
+}
+
 export async function searchParliamentaryProceedings(
   db: Database,
   input: SearchParliamentaryProceedingsInput,
@@ -116,5 +150,5 @@ export async function searchParliamentaryProceedings(
     results = runFtsSearch(db, variants.fallback, date_from, date_to, limit);
   }
 
-  return { results, _metadata: generateResponseMetadata(db) };
+  return { results: addResultCitations(results), _metadata: generateResponseMetadata(db) };
 }

--- a/src/utils/citation.ts
+++ b/src/utils/citation.ts
@@ -17,10 +17,49 @@ export interface CitationMetadata {
   display_text: string;
   aliases?: string[];
   source_url?: string;
+  jurisdiction?: string;
+  source?: string;
+  article?: string;
+  publisher?: string;
+  license?: string;
+  effective_date?: string;
   lookup: {
     tool: string;
     args: Record<string, string>;
   };
+}
+
+export interface CitationAttribution {
+  jurisdiction?: string | null;
+  source?: string | null;
+  article?: string | null;
+  publisher?: string | null;
+  license?: string | null;
+  effective_date?: string | null;
+}
+
+function addIfPresent(
+  citation: CitationMetadata,
+  key: keyof CitationAttribution,
+  value: string | null | undefined,
+): void {
+  if (value && value.trim()) {
+    citation[key] = value;
+  }
+}
+
+export function withCitationAttribution(
+  citation: CitationMetadata,
+  attribution: CitationAttribution,
+): CitationMetadata {
+  const attributed: CitationMetadata = { ...citation };
+  addIfPresent(attributed, 'jurisdiction', attribution.jurisdiction);
+  addIfPresent(attributed, 'source', attribution.source);
+  addIfPresent(attributed, 'article', attribution.article);
+  addIfPresent(attributed, 'publisher', attribution.publisher);
+  addIfPresent(attributed, 'license', attribution.license);
+  addIfPresent(attributed, 'effective_date', attribution.effective_date);
+  return attributed;
 }
 
 /**

--- a/tests/tools/search-case-law.test.ts
+++ b/tests/tools/search-case-law.test.ts
@@ -20,6 +20,21 @@ describe('searchCaseLaw', () => {
     expect(result._metadata.disclaimer).toContain('NOT LEGAL ADVICE');
   });
 
+  it('should attach non-empty citation metadata to each result', async () => {
+    const result = await searchCaseLaw(db, { query: 'onrechtmatige daad' });
+    expect(result.results.length).toBeGreaterThan(0);
+
+    for (const row of result.results) {
+      expect(row._citation?.canonical_ref).toBeTruthy();
+      expect(row._citation?.canonical_ref).toContain('ECLI:');
+      expect(row._citation?.article).toBeTruthy();
+      expect(row._citation?.source).toBeTruthy();
+      expect(row._citation?.source_url).toMatch(/^https:\/\/uitspraken\.rechtspraak\.nl\//);
+      expect(row._citation?.publisher).toBe('De Rechtspraak (Dutch Judiciary)');
+      expect(row._citation?.lookup.tool).toBe('search_case_law');
+    }
+  });
+
   it('should find case law by FTS query', async () => {
     const result = await searchCaseLaw(db, { query: 'onrechtmatige daad' });
     expect(result.results.length).toBeGreaterThan(0);

--- a/tests/tools/search-legislation.test.ts
+++ b/tests/tools/search-legislation.test.ts
@@ -20,6 +20,21 @@ describe('searchLegislation', () => {
     expect(result._metadata.disclaimer).toContain('NOT LEGAL ADVICE');
   });
 
+  it('should attach non-empty citation metadata to each result', async () => {
+    const result = await searchLegislation(db, { query: 'onrechtmatige daad' });
+    expect(result.results.length).toBeGreaterThan(0);
+
+    for (const row of result.results) {
+      expect(row._citation?.canonical_ref).toBeTruthy();
+      expect(row._citation?.display_text).toBeTruthy();
+      expect(row._citation?.article).toBeTruthy();
+      expect(row._citation?.source).toBeTruthy();
+      expect(row._citation?.source_url).toMatch(/^https:\/\/wetten\.overheid\.nl\//);
+      expect(row._citation?.publisher).toBe('Dutch Government (wetten.overheid.nl)');
+      expect(row._citation?.lookup.tool).toBe('get_provision');
+    }
+  });
+
   it('should find provisions matching FTS query', async () => {
     const result = await searchLegislation(db, { query: 'onrechtmatige daad' });
     expect(result.results.length).toBeGreaterThan(0);

--- a/tests/tools/search-parliamentary-proceedings.test.ts
+++ b/tests/tools/search-parliamentary-proceedings.test.ts
@@ -20,6 +20,21 @@ describe('searchParliamentaryProceedings', () => {
     expect(result._metadata.disclaimer).toContain('NOT LEGAL ADVICE');
   });
 
+  it('should attach non-empty citation metadata to each result', async () => {
+    const result = await searchParliamentaryProceedings(db, { query: 'privacy' });
+    expect(result.results.length).toBeGreaterThan(0);
+
+    for (const row of result.results) {
+      expect(row._citation?.canonical_ref).toBeTruthy();
+      expect(row._citation?.display_text).toBeTruthy();
+      expect(row._citation?.article).toBeTruthy();
+      expect(row._citation?.source).toBeTruthy();
+      expect(row._citation?.source_url).toMatch(/^https:\/\/www\.tweedekamer\.nl\//);
+      expect(row._citation?.publisher).toBe('Tweede Kamer / ParlaMint-NL');
+      expect(row._citation?.lookup.tool).toBe('search_parliamentary_proceedings');
+    }
+  });
+
   it('should find proceedings by FTS query', async () => {
     const result = await searchParliamentaryProceedings(db, { query: 'persoonsgegevens' });
     expect(result.results.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What changed

- Supersedes the stale Dependabot updates for `hono` and `brace-expansion`.
- Replaces the Unix-only `postinstall` shell expression with a cross-platform Node command.
- Adds per-result `_citation` metadata to `search_legislation`, `search_case_law`, and `search_parliamentary_proceedings`.
- Extends `get_provision` citation metadata with source URL, source, article, publisher, license, and effective date fields.
- Adds build-time seed validation for empty citation identity fields.
- Adds regression tests that fail when search results ship empty citation/source metadata.

## Why

The 2026-05-06 golden-standard audit failed on stale dependency PRs and two open bug defects:

- Closes #59
- Closes #61

The root cause for #59 was that search result rows returned the legal text fields but did not attach the structured citation object expected by downstream gateway/compliance artefact generation.

## Validation

- `npm ci`
- `npm run build`
- `npm test` (313/313)
- `npx eslint src/utils/citation.ts src/tools/search-legislation.ts src/tools/search-case-law.ts src/tools/search-parliamentary-proceedings.ts src/tools/get-provision.ts scripts/build-db.ts tests/tools/search-legislation.test.ts tests/tools/search-case-law.test.ts tests/tools/search-parliamentary-proceedings.test.ts`
- `npm audit --omit=dev --json` reports 0 high / 0 critical, with moderate advisories remaining in the MCP SDK dependency chain.

## Notes

`npm run test:contract` still cannot complete in this dev clone because `data/database.db` is not present locally; this was already captured by the earlier audit history.
