### PR TITLE
fix: relax DB size check to accept current ~123 MB corpus (#68)

### DIFF
--- a/src/utils/ensure-database.ts
+++ b/src/utils/ensure-database.ts
@@ -73,13 +73,23 @@ function getCachePath(): string {
 // Size validation
 // ---------------------------------------------------------------------------
 
-const MIN_SIZE = 900 * 1024 * 1024; // 900 MB
-const MAX_SIZE = 1.2 * 1024 * 1024 * 1024; // 1.2 GB
+// Sanity bounds — DB ranges from ~80 MB (free tier) to ~5 GB (premium upper
+// bound). Tightening the lower bound risks false rejection when the corpus
+// shrinks (e.g., source legitimacy takedown). Tightening the upper bound
+// risks false rejection on premium tier growth. The point of this check is
+// only to detect a corrupt/error-page download, not to assert exact size.
+const MIN_SIZE = 50 * 1024 * 1024; // 50 MB — below this is almost certainly an error page or partial download
+const MAX_SIZE = 5 * 1024 * 1024 * 1024; // 5 GB — above this is a redirect loop or wrong asset
+
+export function isAcceptableDbSize(bytes: number): boolean {
+  return bytes >= MIN_SIZE && bytes <= MAX_SIZE;
+}
 
 function validateSize(filePath: string): boolean {
   try {
     const stat = fs.statSync(filePath);
-    return stat.size >= MIN_SIZE && stat.size <= MAX_SIZE;
+    process.stderr.write(`[dutch-law-mcp] Downloaded database size: ${formatBytes(stat.size)}\n`);
+    return isAcceptableDbSize(stat.size);
   } catch {
     return false;
   }

--- a/tests/utils/ensure-database.test.ts
+++ b/tests/utils/ensure-database.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAcceptableDbSize } from '../../src/utils/ensure-database.js';
+
+describe('isAcceptableDbSize', () => {
+  it('accepts the current ~123 MB free-tier DB', () => {
+    expect(isAcceptableDbSize(123 * 1024 * 1024)).toBe(true);
+  });
+
+  it('accepts a future ~500 MB premium DB', () => {
+    expect(isAcceptableDbSize(500 * 1024 * 1024)).toBe(true);
+  });
+
+  it('rejects a 1 KB error response masquerading as the DB', () => {
+    expect(isAcceptableDbSize(1024)).toBe(false);
+  });
+
+  it('rejects an absurd 10 GB payload', () => {
+    expect(isAcceptableDbSize(10 * 1024 * 1024 * 1024)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #68. `postinstall` was failing every fresh install because `ensure-database.ts` hardcoded `MIN_SIZE = 900 MB`, but the published `database.db.gz` decompresses to ~123 MB on the free tier.

## Changes

- `src/utils/ensure-database.ts` — replace hard min/max (900 MB / 1.2 GB) with a sanity range (50 MB / 5 GB). Export a new `isAcceptableDbSize(bytes)` for testability. Log the actual decompressed size to stderr so future drift is observable.
- `tests/utils/ensure-database.test.ts` — 4 new TDD tests cover the 123 MB pass case, a 500 MB premium-tier projection, a 1 KB error-page rejection, and a 10 GB redirect-loop rejection.

## Reasoning

The point of the size check is to detect a corrupt or error-page download, not to assert exact size. Tightening the lower bound risks false rejection when the corpus shrinks (source-legitimacy takedowns); tightening the upper bound risks false rejection on premium-tier growth. 50 MB / 5 GB is the minimum viable sanity range that catches the failure modes that actually matter (error pages, redirect loops).

## Verification

- `npm test` — 317/317 passing (313 baseline + 4 new).
- `rm -rf ~/.cache/dutch-law-mcp && node -e "import('./dist/utils/ensure-database.js').then(m => m.ensureDatabase())"` — fresh install completes with stderr `Downloaded database size: 123 MB`, exits 0, cache file at 124 MB.

## Plan reference

Phase 1 of `docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md` in arch-docs (PR #401, merged).