### PR TITLE
fix(citation): catalog license code + always-on _citation on get_provision

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -145,28 +145,27 @@ export async function getProvision(
   const firstResult = results.length > 0 ? results[0] : null;
   return {
     results,
-    ...(provisionRef &&
-      firstResult && {
-        _citation: withCitationAttribution(
-          buildProvisionCitation(
-            firstResult.document_id,
-            firstResult.document_title || '',
-            firstResult.provision_ref || '',
-            input.document_id,
-            input.section || input.provision_ref || input.article || '',
-            firstResult.source_url,
-            null,
-          ),
-          {
-            jurisdiction: 'NL',
-            source: firstResult.document_title,
-            article: firstResult.article || firstResult.provision_ref,
-            publisher: 'Dutch Government (wetten.overheid.nl)',
-            license: 'Dutch government open data',
-            effective_date: firstResult.effective_date || firstResult.valid_from || null,
-          },
+    ...(firstResult && {
+      _citation: withCitationAttribution(
+        buildProvisionCitation(
+          firstResult.document_id,
+          firstResult.document_title || '',
+          firstResult.provision_ref || '',
+          input.document_id,
+          input.section || input.provision_ref || input.article || provisionRef || '',
+          firstResult.source_url,
+          null,
         ),
-      }),
+        {
+          jurisdiction: 'NL',
+          source: firstResult.document_title,
+          article: firstResult.article || firstResult.provision_ref || null,
+          publisher: 'Dutch Government (wetten.overheid.nl)',
+          license: 'Public-Domain',
+          effective_date: firstResult.effective_date || firstResult.valid_from || null,
+        },
+      ),
+    }),
     _metadata: generateResponseMetadata(db),
   };
 }

--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -70,7 +70,7 @@ function addResultCitations(rows: SearchCaseLawResult[]): SearchCaseLawResult[] 
         source: row.court || 'rechtspraak.nl',
         article: canonicalRef,
         publisher: 'De Rechtspraak (Dutch Judiciary)',
-        license: 'Open justice data',
+        license: 'Public-Domain',
         effective_date: row.decision_date,
       }),
     };

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -194,7 +194,7 @@ function addResultCitations(rows: SearchLegislationResult[]): SearchLegislationR
         source: row.document_title,
         article: row.article || row.provision_ref,
         publisher: 'Dutch Government (wetten.overheid.nl)',
-        license: 'Dutch government open data',
+        license: 'Public-Domain',
         effective_date: row.effective_date || row.valid_from || null,
       }),
     };

--- a/src/tools/search-parliamentary-proceedings.ts
+++ b/src/tools/search-parliamentary-proceedings.ts
@@ -102,7 +102,7 @@ function addResultCitations(
         source: row.title,
         article: row.related_statute_id || canonicalRef,
         publisher: 'Tweede Kamer / ParlaMint-NL',
-        license: 'Dutch parliamentary open data',
+        license: 'Public-Domain',
         effective_date: row.issued_date,
       }),
     };

--- a/tests/tools/get-provision.test.ts
+++ b/tests/tools/get-provision.test.ts
@@ -132,4 +132,20 @@ describe('getProvision', () => {
     expect(result.results).toHaveLength(1);
     expect(result.results[0].title).toBe('Beroep bij de bestuursrechter');
   });
+
+  it('emits _citation with Public-Domain license on the article path', async () => {
+    const result = await getProvision(db, { document_id: 'BWBR0005289', provision_ref: '6:162' });
+    expect(result._citation).toBeDefined();
+    expect(result._citation?.license).toBe('Public-Domain');
+    expect(result._citation?.publisher).toBe('Dutch Government (wetten.overheid.nl)');
+    expect(result._citation?.canonical_ref).toBeTruthy();
+  });
+
+  it('emits _citation when caller provides only document_id (no article)', async () => {
+    const result = await getProvision(db, { document_id: 'BWBR0001854' });
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result._citation).toBeDefined();
+    expect(result._citation?.license).toBe('Public-Domain');
+    expect(result._citation?.canonical_ref).toBeTruthy();
+  });
 });

--- a/tests/tools/search-case-law.test.ts
+++ b/tests/tools/search-case-law.test.ts
@@ -31,6 +31,7 @@ describe('searchCaseLaw', () => {
       expect(row._citation?.source).toBeTruthy();
       expect(row._citation?.source_url).toMatch(/^https:\/\/uitspraken\.rechtspraak\.nl\//);
       expect(row._citation?.publisher).toBe('De Rechtspraak (Dutch Judiciary)');
+      expect(row._citation?.license).toBe('Public-Domain');
       expect(row._citation?.lookup.tool).toBe('search_case_law');
     }
   });

--- a/tests/tools/search-legislation.test.ts
+++ b/tests/tools/search-legislation.test.ts
@@ -31,6 +31,7 @@ describe('searchLegislation', () => {
       expect(row._citation?.source).toBeTruthy();
       expect(row._citation?.source_url).toMatch(/^https:\/\/wetten\.overheid\.nl\//);
       expect(row._citation?.publisher).toBe('Dutch Government (wetten.overheid.nl)');
+      expect(row._citation?.license).toBe('Public-Domain');
       expect(row._citation?.lookup.tool).toBe('get_provision');
     }
   });

--- a/tests/tools/search-parliamentary-proceedings.test.ts
+++ b/tests/tools/search-parliamentary-proceedings.test.ts
@@ -31,6 +31,7 @@ describe('searchParliamentaryProceedings', () => {
       expect(row._citation?.source).toBeTruthy();
       expect(row._citation?.source_url).toMatch(/^https:\/\/www\.tweedekamer\.nl\//);
       expect(row._citation?.publisher).toBe('Tweede Kamer / ParlaMint-NL');
+      expect(row._citation?.license).toBe('Public-Domain');
       expect(row._citation?.lookup.tool).toBe('search_parliamentary_proceedings');
     }
   });


### PR DESCRIPTION
## Summary

Two follow-through fixes from the PR #67 code review (which merged with these findings unfixed). Refs #60.

### Finding 1 — License catalog violation

Four tool files were emitting `_citation.license` as free-form prose:
- `src/tools/search-legislation.ts:197` — \`'Dutch government open data'\`
- `src/tools/get-provision.ts:165` — \`'Dutch government open data'\`
- `src/tools/search-case-law.ts:73` — \`'Open justice data'\`
- `src/tools/search-parliamentary-proceedings.ts:105` — \`'Dutch parliamentary open data'\`

But `backstage/catalog/fleet-manifests/dutch-law.json` declares \`attribution.license = "Public-Domain"\` — that's the catalog code from \`infrastructure/attribution-licenses.json\`. Per the Source Attribution Standard (Gate 13), per-item \`_citation.license\` must match the catalog code.

All four sites now emit \`'Public-Domain'\`. Tests in 4 test files updated to assert this.

### Finding 2 — \`_citation\` silently omitted on document-only path

\`get_provision\` is documented to accept just \`document_id\` and return all provisions of the statute. But the citation guard required \`provisionRef\` (undefined on that path):

\`\`\`typescript
...(provisionRef && firstResult && { _citation: ... })
\`\`\`

This caused the response to fail the watchdog \`citation_present\` assertion on the document-only call path. Fixed: drop the \`provisionRef\` requirement so the guard becomes \`firstResult && { _citation: ... }\`. Article-path responses still get a precise reference; document-only responses now get a document-level citation.

## Verification

- \`npx eslint src/ tests/\` — clean (CI lint scope).
- \`npm test\` — 319/319 (317 baseline + 2 new \`_citation\` tests on get-provision; license-on-existing-test additions in 3 other test files modify existing assertions, no count change).
- \`npm run test:contract\` — fails locally with missing-DB error, same pre-existing pattern as Phase 1; CI provisions the DB and runs green.

## Plan reference

Phase 2 of \`docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md\` in arch-docs (PR #401, merged).