### PR TITLE
fix(citation): key case-law lookup.args by document_id when ECLI null

### DIFF
--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -52,11 +52,14 @@ function addResultCitations(rows: SearchCaseLawResult[]): SearchCaseLawResult[] 
   return rows.map((row) => {
     const canonicalRef = row.ecli || row.document_id;
     const displayText = [row.court, row.decision_date, canonicalRef].filter(Boolean).join(' ');
+    const lookupArgs: Record<string, string> = row.ecli
+      ? { ecli: row.ecli }
+      : { document_id: row.document_id };
     const citation = buildCitation(
       canonicalRef,
       displayText,
       'search_case_law',
-      { ecli: canonicalRef },
+      lookupArgs,
       row.url || ecliToUrl(row.ecli),
       [row.document_id, row.case_number, row.document_title].filter((value): value is string =>
         Boolean(value),

--- a/tests/fixtures/test-db.ts
+++ b/tests/fixtures/test-db.ts
@@ -385,6 +385,18 @@ const SAMPLE_DOCUMENTS = [
     description: 'Onrechtmatige daad; schadevergoeding',
   },
   {
+    id: 'INT-CASE-NULL-ECLI-001',
+    type: 'case_law',
+    title: 'Internal case identifier (no ECLI assigned)',
+    title_en: null,
+    short_name: null,
+    status: 'in_force',
+    issued_date: '2024-01-15',
+    in_force_date: null,
+    url: null,
+    description: 'Synthetic fixture for null-ecli lookup keying test',
+  },
+  {
     id: 'ECLI:NL:RVS:2020:1234',
     type: 'case_law',
     title: 'Raad van State 10 juni 2020',
@@ -590,6 +602,17 @@ const SAMPLE_CASE_LAW = [
     summary:
       'De Afdeling bestuursrechtspraak van de Raad van State bevestigde het besluit van het bestuursorgaan inzake handhaving op grond van de Algemene wet bestuursrecht.',
     keywords: 'bestuursrecht handhaving Awb besluit bestuursorgaan',
+  },
+  {
+    document_id: 'INT-CASE-NULL-ECLI-001',
+    court: 'CBb',
+    ecli: null,
+    case_number: 'INT-2024-001',
+    decision_date: '2024-01-15',
+    procedure_type: 'Bezwaar',
+    legal_domain: 'Bestuursrecht',
+    summary: 'synthetisch fixture nullecli token',
+    keywords: 'nullecli synthetisch fixture',
   },
 ];
 

--- a/tests/tools/search-case-law.test.ts
+++ b/tests/tools/search-case-law.test.ts
@@ -139,4 +139,14 @@ describe('searchCaseLaw', () => {
     expect(rvs).toBeDefined();
     expect(rvs!.ecli).toBe('ECLI:NL:RVS:2020:1234');
   });
+
+  it('keys lookup.args by document_id when ecli is null', async () => {
+    const result = await searchCaseLaw(db, { query: 'nullecli' });
+    expect(result.results.length).toBeGreaterThan(0);
+    const row = result.results.find((r) => r.document_id === 'INT-CASE-NULL-ECLI-001');
+    expect(row).toBeDefined();
+    expect(row!.ecli).toBeNull();
+    expect(row!._citation?.lookup.args).toEqual({ document_id: 'INT-CASE-NULL-ECLI-001' });
+    expect(row!._citation?.lookup.args).not.toHaveProperty('ecli');
+  });
 });


### PR DESCRIPTION
## Summary

PR #67 review finding (score 75): \`addResultCitations\` in \`search-case-law.ts\` wraps the canonical reference in \`{ ecli: canonicalRef }\` unconditionally. When \`row.ecli\` is null, \`canonicalRef\` falls back to \`row.document_id\` — but the lookup args key still says \`ecli\`. Downstream re-lookup then receives an internal document_id under the wrong name.

## Fix

\`\`\`ts
const lookupArgs = row.ecli ? { ecli: row.ecli } : { document_id: row.document_id };
\`\`\`

Article path unchanged.

## Verification

- 1 new test in \`tests/tools/search-case-law.test.ts\` exercises the null-ecli path.
- New synthetic fixture pair (\`legal_documents\` + \`case_law\`) with \`ecli: null\` and \`document_id: 'INT-CASE-NULL-ECLI-001'\`.
- 320/320 unit tests pass.
- ESLint clean (CI scope).

## Plan reference

Phase 5C of \`docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md\` in arch-docs (PR #401, merged).