### PR TITLE
fix(citation): fall back to publisher URL when parliamentary row.url is null

### DIFF
--- a/src/tools/search-parliamentary-proceedings.ts
+++ b/src/tools/search-parliamentary-proceedings.ts
@@ -86,12 +86,16 @@ function addResultCitations(
 ): SearchParliamentaryProceedingsResult[] {
   return rows.map((row) => {
     const canonicalRef = `NL parliamentary proceeding ${row.id}`;
+    // Publisher-level fallback for items missing an upstream URL. Item-level
+    // null is common for older ParlaMint entries where the verbatim transcript
+    // was archived before the kamerstukken portal added per-speaker permalinks.
+    const sourceUrl = row.url ?? 'https://www.tweedekamer.nl/';
     const citation = buildCitation(
       canonicalRef,
       row.title || canonicalRef,
       'search_parliamentary_proceedings',
       { query: row.title || canonicalRef },
-      row.url,
+      sourceUrl,
       [row.related_statute_id].filter((value): value is string => Boolean(value)),
     );
 

--- a/tests/fixtures/test-db.ts
+++ b/tests/fixtures/test-db.ts
@@ -662,6 +662,17 @@ const SAMPLE_AGENCY_GUIDANCE = [
     url: 'https://www.tweedekamer.nl/kamerstukken/plenaire_verslagen',
     related_statute_id: null,
   },
+  {
+    agency: 'tweede-kamer',
+    document_id: null,
+    title: '2024-04-01 — NullUrlSpeaker',
+    summary: 'synthetisch nullurltoken fixture for source-url fallback test',
+    full_text:
+      'Synthetic fixture row to verify the publisher-level source_url fallback when the upstream url field is null.',
+    issued_date: '2024-04-01',
+    url: null,
+    related_statute_id: null,
+  },
 ];
 
 const SAMPLE_DEFINITIONS = [

--- a/tests/tools/search-parliamentary-proceedings.test.ts
+++ b/tests/tools/search-parliamentary-proceedings.test.ts
@@ -109,4 +109,13 @@ describe('searchParliamentaryProceedings', () => {
     expect(withStatute).toBeDefined();
     expect(withStatute!.related_statute_id).toBe('BWBR0042124');
   });
+
+  it('falls back to publisher URL when row.url is null', async () => {
+    const result = await searchParliamentaryProceedings(db, { query: 'nullurltoken' });
+    expect(result.results.length).toBeGreaterThan(0);
+    const row = result.results.find((r) => r.title.includes('NullUrlSpeaker'));
+    expect(row).toBeDefined();
+    expect(row!.url).toBeNull();
+    expect(row!._citation?.source_url).toBe('https://www.tweedekamer.nl/');
+  });
 });


### PR DESCRIPTION
## Summary

PR #67 review finding (score 75): when a parliamentary row has \`url = NULL\`, \`addResultCitations\` passed it straight through to \`buildCitation\`, which omits \`source_url\` from \`_citation\` entirely. Watchdog \`source_url\` assertions then failed.

## Fix

\`\`\`ts
const sourceUrl = row.url ?? 'https://www.tweedekamer.nl/';
\`\`\`

Publisher-level fallback. Item-level URLs (when present) remain authoritative.

## Verification

- 1 new test in \`tests/tools/search-parliamentary-proceedings.test.ts\` exercises the null-url path.
- New synthetic \`SAMPLE_AGENCY_GUIDANCE\` fixture row with \`url: null\`.
- 321/321 unit tests pass.
- ESLint clean (CI scope).

## Plan reference

Phase 5B of \`docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md\` in arch-docs (PR #401, merged).