### PR TITLE
fix(build-db): add FK validation for case_law + preparatory_works seeds

### DIFF
--- a/scripts/build-db.ts
+++ b/scripts/build-db.ts
@@ -13,6 +13,15 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  validateCitationSeedFields,
+  type CaseLawSeed,
+  type DocumentSeed,
+  type PreparatoryWorkSeed,
+  type ProvisionSeed,
+  type ProvisionVersionSeed,
+} from './seed-validator.js';
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -281,66 +290,6 @@ CREATE TABLE IF NOT EXISTS db_metadata (
 // Seed file types
 // ---------------------------------------------------------------------------
 
-interface DocumentSeed {
-  id: string;
-  type: 'statute' | 'amvb' | 'ministerial_regulation' | 'kamerstuk' | 'case_law';
-  title: string;
-  title_en?: string;
-  short_name?: string;
-  status?: string;
-  issued_date?: string;
-  in_force_date?: string;
-  url?: string;
-  description?: string;
-}
-
-interface ProvisionSeed {
-  document_id: string;
-  provision_ref: string;
-  book?: string;
-  chapter?: string;
-  section?: string;
-  article: string;
-  title?: string;
-  content: string;
-  metadata?: string;
-}
-
-interface ProvisionVersionSeed {
-  document_id: string;
-  provision_ref: string;
-  book?: string;
-  chapter?: string;
-  section?: string;
-  article: string;
-  title?: string;
-  content: string;
-  metadata?: string;
-  valid_from?: string;
-  valid_to?: string;
-}
-
-interface CaseLawSeed {
-  document_id: string;
-  court: string;
-  ecli?: string;
-  case_number?: string;
-  decision_date?: string;
-  procedure_type?: string;
-  legal_domain?: string;
-  summary?: string;
-  keywords?: string;
-}
-
-interface PreparatoryWorkSeed {
-  statute_id: string;
-  prep_document_id: string;
-  kamerstuk_ref?: string;
-  document_type?: string;
-  title?: string;
-  summary?: string;
-}
-
 interface DefinitionSeed {
   document_id: string;
   term: string;
@@ -432,75 +381,6 @@ function readSeedFiles(): SeedFile[] {
   }
 
   return seeds;
-}
-
-function isBlank(value: string | undefined): boolean {
-  return value == null || value.trim() === '';
-}
-
-function validateCitationSeedFields(seeds: SeedFile[]): void {
-  const documentIds = new Set<string>();
-
-  for (const seed of seeds) {
-    for (const doc of seed.documents ?? []) {
-      if (isBlank(doc.id) || isBlank(doc.title)) {
-        throw new Error(
-          `Citation metadata requires non-empty document id and title: ${JSON.stringify(doc)}`,
-        );
-      }
-      documentIds.add(doc.id);
-    }
-  }
-
-  for (const seed of seeds) {
-    for (const provision of seed.provisions ?? []) {
-      if (
-        isBlank(provision.document_id) ||
-        isBlank(provision.provision_ref) ||
-        isBlank(provision.article)
-      ) {
-        throw new Error(
-          `Citation metadata requires non-empty provision document_id, provision_ref, and article: ${JSON.stringify(
-            provision,
-          )}`,
-        );
-      }
-      if (!documentIds.has(provision.document_id)) {
-        throw new Error(
-          `Citation metadata requires a source document for provision ${provision.document_id}:${provision.provision_ref}`,
-        );
-      }
-    }
-
-    for (const provision of seed.provision_versions ?? []) {
-      if (
-        isBlank(provision.document_id) ||
-        isBlank(provision.provision_ref) ||
-        isBlank(provision.article)
-      ) {
-        throw new Error(
-          `Citation metadata requires non-empty versioned provision document_id, provision_ref, and article: ${JSON.stringify(
-            provision,
-          )}`,
-        );
-      }
-      if (!documentIds.has(provision.document_id)) {
-        throw new Error(
-          `Citation metadata requires a source document for versioned provision ${provision.document_id}:${provision.provision_ref}`,
-        );
-      }
-    }
-
-    for (const caseLaw of seed.case_law ?? []) {
-      if (isBlank(caseLaw.document_id) || isBlank(caseLaw.ecli) || isBlank(caseLaw.court)) {
-        throw new Error(
-          `Citation metadata requires non-empty case law document_id, ecli, and court: ${JSON.stringify(
-            caseLaw,
-          )}`,
-        );
-      }
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed-validator.ts
+++ b/scripts/seed-validator.ts
@@ -1,0 +1,171 @@
+/**
+ * seed-validator.ts — Citation seed integrity checks.
+ *
+ * Extracted from build-db.ts so the validator can be unit-tested without
+ * triggering the full build-db CLI side effects on import.
+ */
+
+export interface DocumentSeed {
+  id: string;
+  type: 'statute' | 'amvb' | 'ministerial_regulation' | 'kamerstuk' | 'case_law';
+  title: string;
+  title_en?: string;
+  short_name?: string;
+  status?: string;
+  issued_date?: string;
+  in_force_date?: string;
+  url?: string;
+  description?: string;
+}
+
+export interface ProvisionSeed {
+  document_id: string;
+  provision_ref: string;
+  book?: string;
+  chapter?: string;
+  section?: string;
+  article: string;
+  title?: string;
+  content: string;
+  metadata?: string;
+}
+
+export interface ProvisionVersionSeed {
+  document_id: string;
+  provision_ref: string;
+  book?: string;
+  chapter?: string;
+  section?: string;
+  article: string;
+  title?: string;
+  content: string;
+  metadata?: string;
+  valid_from?: string;
+  valid_to?: string;
+}
+
+export interface CaseLawSeed {
+  document_id: string;
+  court: string;
+  ecli?: string;
+  case_number?: string;
+  decision_date?: string;
+  procedure_type?: string;
+  legal_domain?: string;
+  summary?: string;
+  keywords?: string;
+}
+
+export interface PreparatoryWorkSeed {
+  statute_id: string;
+  prep_document_id: string;
+  kamerstuk_ref?: string;
+  document_type?: string;
+  title?: string;
+  summary?: string;
+}
+
+export interface SeedFile {
+  documents?: DocumentSeed[];
+  provisions?: ProvisionSeed[];
+  provision_versions?: ProvisionVersionSeed[];
+  case_law?: CaseLawSeed[];
+  preparatory_works?: PreparatoryWorkSeed[];
+  // Other top-level keys (definitions, cross_references, eu_*) exist on the
+  // SeedFile shape used by build-db.ts but aren't validated here yet.
+  [key: string]: unknown;
+}
+
+export function isBlank(value: string | undefined): boolean {
+  return value == null || value.trim() === '';
+}
+
+export function validateCitationSeedFields(seeds: SeedFile[]): void {
+  const documentIds = new Set<string>();
+
+  for (const seed of seeds) {
+    for (const doc of seed.documents ?? []) {
+      if (isBlank(doc.id) || isBlank(doc.title)) {
+        throw new Error(
+          `Citation metadata requires non-empty document id and title: ${JSON.stringify(doc)}`,
+        );
+      }
+      documentIds.add(doc.id);
+    }
+  }
+
+  for (const seed of seeds) {
+    for (const provision of seed.provisions ?? []) {
+      if (
+        isBlank(provision.document_id) ||
+        isBlank(provision.provision_ref) ||
+        isBlank(provision.article)
+      ) {
+        throw new Error(
+          `Citation metadata requires non-empty provision document_id, provision_ref, and article: ${JSON.stringify(
+            provision,
+          )}`,
+        );
+      }
+      if (!documentIds.has(provision.document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for provision ${provision.document_id}:${provision.provision_ref}`,
+        );
+      }
+    }
+
+    for (const provision of seed.provision_versions ?? []) {
+      if (
+        isBlank(provision.document_id) ||
+        isBlank(provision.provision_ref) ||
+        isBlank(provision.article)
+      ) {
+        throw new Error(
+          `Citation metadata requires non-empty versioned provision document_id, provision_ref, and article: ${JSON.stringify(
+            provision,
+          )}`,
+        );
+      }
+      if (!documentIds.has(provision.document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for versioned provision ${provision.document_id}:${provision.provision_ref}`,
+        );
+      }
+    }
+
+    for (const caseLaw of seed.case_law ?? []) {
+      if (isBlank(caseLaw.document_id) || isBlank(caseLaw.court)) {
+        throw new Error(
+          `Citation metadata requires non-empty case law document_id and court: ${JSON.stringify(
+            caseLaw,
+          )}`,
+        );
+      }
+      if (!documentIds.has(caseLaw.document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for case law ${caseLaw.document_id} (FK violation)`,
+        );
+      }
+    }
+
+    for (const prep of seed.preparatory_works ?? []) {
+      if (isBlank(prep.statute_id) || isBlank(prep.prep_document_id)) {
+        throw new Error(
+          `Citation metadata requires non-empty preparatory work statute_id and prep_document_id: ${JSON.stringify(
+            prep,
+          )}`,
+        );
+      }
+      if (!documentIds.has(prep.statute_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for preparatory work statute_id ${prep.statute_id} (FK violation)`,
+        );
+      }
+      if (!documentIds.has(prep.prep_document_id)) {
+        throw new Error(
+          `Citation metadata requires a source document for preparatory work prep_document_id ${prep.prep_document_id} (FK violation)`,
+        );
+      }
+    }
+  }
+}

--- a/tests/scripts/seed-validator.test.ts
+++ b/tests/scripts/seed-validator.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateCitationSeedFields, type SeedFile } from '../../scripts/seed-validator.js';
+
+const docAuteurswet = {
+  id: 'BWBR0001886',
+  type: 'statute' as const,
+  title: 'Auteurswet',
+  status: 'in_force',
+};
+
+const docCaseHR = {
+  id: 'ECLI:NL:HR:2026:1',
+  type: 'case_law' as const,
+  title: 'Hoge Raad 1 januari 2026',
+  status: 'in_force',
+};
+
+describe('validateCitationSeedFields', () => {
+  it('passes a minimal valid seed', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docAuteurswet],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).not.toThrow();
+  });
+
+  it('rejects a case_law row whose document_id is not in legal_documents (FK violation)', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docAuteurswet],
+        case_law: [
+          {
+            document_id: 'BWBR9999999',
+            ecli: 'ECLI:NL:HR:2026:1',
+            court: 'HR',
+          },
+        ],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).toThrow(
+      /case law BWBR9999999 \(FK violation\)/,
+    );
+  });
+
+  it('accepts case_law with ecli=null when document_id and court are present and FK valid', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docCaseHR],
+        case_law: [
+          {
+            document_id: 'ECLI:NL:HR:2026:1',
+            court: 'HR',
+            // ecli intentionally absent
+          },
+        ],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).not.toThrow();
+  });
+
+  it('rejects preparatory_works with empty statute_id', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docAuteurswet],
+        preparatory_works: [
+          {
+            statute_id: '',
+            prep_document_id: 'KST-1234-5',
+            kamerstuk_ref: 'Kamerstukken II 2026/27, 1234, nr. 5',
+          },
+        ],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).toThrow(/non-empty preparatory work/);
+  });
+
+  it('rejects preparatory_works whose statute_id is not in legal_documents (FK violation)', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docAuteurswet],
+        preparatory_works: [
+          {
+            statute_id: 'BWBR_DOES_NOT_EXIST',
+            prep_document_id: 'BWBR0001886',
+          },
+        ],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).toThrow(
+      /preparatory work statute_id BWBR_DOES_NOT_EXIST \(FK violation\)/,
+    );
+  });
+
+  it('rejects preparatory_works whose prep_document_id is not in legal_documents (FK violation)', () => {
+    const seeds: SeedFile[] = [
+      {
+        documents: [docAuteurswet],
+        preparatory_works: [
+          {
+            statute_id: 'BWBR0001886',
+            prep_document_id: 'KST_DOES_NOT_EXIST',
+          },
+        ],
+      },
+    ];
+    expect(() => validateCitationSeedFields(seeds)).toThrow(
+      /preparatory work prep_document_id KST_DOES_NOT_EXIST \(FK violation\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PR #67 review finding (score 75): \`validateCitationSeedFields\` in \`scripts/build-db.ts\` checked provisions for FK validity but skipped \`case_law\` and \`preparatory_works\` entirely. A typo'd \`document_id\` in a case-law seed would silently produce a row whose downstream lookup never resolves.

## Changes

- **Extract:** \`scripts/seed-validator.ts\` (new) — types + validator. Pulled from \`build-db.ts\` so it can be unit-tested without invoking the build-db CLI's side effects on import.
- **case_law FK check:** \`if (!documentIds.has(caseLaw.document_id)) throw FK violation\`. Mirrors the existing provisions pattern.
- **preparatory_works block:** non-empty \`statute_id\` + \`prep_document_id\`, plus both must exist in \`legal_documents\` (FK). Previously zero seed-level validation.
- **case_law.ecli loosening:** drop \`isBlank(caseLaw.ecli)\` at seed time. Matches runtime null-ecli handling shipped in PR #75 (Phase 5C). Internal case identifiers without an ECLI are now first-class at every layer.

## Verification

- 6 new unit tests in \`tests/scripts/seed-validator.test.ts\` cover the happy path and 5 rejection paths (\`case_law\` FK, \`case_law\` ecli=null OK, \`preparatory_works\` empty, \`preparatory_works\` statute_id FK, \`preparatory_works\` prep_document_id FK).
- \`npm test\` — 326/326.
- \`npx tsc --noEmit\` — clean.
- \`npx eslint src/ tests/\` — clean.

## Plan reference

Phase 5A of \`docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md\` in arch-docs (PR #401, merged).