### PR TITLE
refactor(schema): rename agency_guidance → parliamentary_proceedings (#54)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.15.29",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.27.0",
@@ -1205,6 +1206,16 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.29",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.27.0",

--- a/scripts/build-db-free.ts
+++ b/scripts/build-db-free.ts
@@ -20,7 +20,7 @@
  *   - case_law + case_law_fts
  *   - preparatory_works + prep_works_fts
  *   - case_law_full, preparatory_works_full
- *   - agency_guidance, agency_guidance_fts
+ *   - parliamentary_proceedings, parliamentary_proceedings_fts
  *
  * Usage: npm run build:db:free
  */
@@ -39,7 +39,7 @@ const FREE_DB = path.resolve(__dirname, '..', 'data', 'database-free.db');
 function sql(dbPath: string, query: string): string {
   return execFileSync('sqlite3', [dbPath, query], {
     encoding: 'utf-8',
-    timeout: 600_000,  // 10 minutes for VACUUM on large DBs
+    timeout: 600_000, // 10 minutes for VACUUM on large DBs
   }).trim();
 }
 
@@ -49,7 +49,7 @@ function buildFreeTier(): void {
   if (!fs.existsSync(FULL_DB)) {
     console.error(
       `ERROR: No full database found at ${FULL_DB}\n` +
-      `Run 'npm run build:db' first to create the base database.`
+        `Run 'npm run build:db' first to create the base database.`,
     );
     process.exit(1);
   }
@@ -85,10 +85,14 @@ function buildFreeTier(): void {
 
   // Tables to drop
   const tablesToDrop = [
-    'case_law_fts', 'case_law',
-    'prep_works_fts', 'preparatory_works',
-    'case_law_full', 'preparatory_works_full',
-    'agency_guidance_fts', 'agency_guidance',
+    'case_law_fts',
+    'case_law',
+    'prep_works_fts',
+    'preparatory_works',
+    'case_law_full',
+    'preparatory_works_full',
+    'parliamentary_proceedings_fts',
+    'parliamentary_proceedings',
   ];
 
   console.log('\n  Dropping tables:');
@@ -102,7 +106,10 @@ function buildFreeTier(): void {
   }
 
   // Drop triggers for dropped tables
-  const triggerList = sql(FREE_DB, "SELECT name || '|' || tbl_name FROM sqlite_master WHERE type = 'trigger';");
+  const triggerList = sql(
+    FREE_DB,
+    "SELECT name || '|' || tbl_name FROM sqlite_master WHERE type = 'trigger';",
+  );
   const droppedTableSet = new Set(tablesToDrop);
   for (const line of triggerList.split('\n').filter(Boolean)) {
     const parts = line.split('|');
@@ -115,36 +122,67 @@ function buildFreeTier(): void {
   }
 
   // Remove case_law and kamerstuk entries from legal_documents
-  const caseLawCount = sql(FREE_DB, "SELECT COUNT(*) FROM legal_documents WHERE type = 'case_law';");
-  const kamerstukCount = sql(FREE_DB, "SELECT COUNT(*) FROM legal_documents WHERE type = 'kamerstuk';");
+  const caseLawCount = sql(
+    FREE_DB,
+    "SELECT COUNT(*) FROM legal_documents WHERE type = 'case_law';",
+  );
+  const kamerstukCount = sql(
+    FREE_DB,
+    "SELECT COUNT(*) FROM legal_documents WHERE type = 'kamerstuk';",
+  );
 
   if (parseInt(caseLawCount) > 0) {
     // Clean up eu_references pointing to case_law documents
     if (existingTables.has('eu_references')) {
       sql(FREE_DB, "DELETE FROM eu_references WHERE source_type = 'case_law';");
-      sql(FREE_DB, "DELETE FROM eu_references WHERE document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law');");
+      sql(
+        FREE_DB,
+        "DELETE FROM eu_references WHERE document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law');",
+      );
     }
 
     // Clean up cross_references pointing to case_law documents
     if (existingTables.has('cross_references')) {
-      sql(FREE_DB, `DELETE FROM cross_references WHERE source_document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law') OR target_document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law');`);
+      sql(
+        FREE_DB,
+        `DELETE FROM cross_references WHERE source_document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law') OR target_document_id IN (SELECT id FROM legal_documents WHERE type = 'case_law');`,
+      );
     }
 
     sql(FREE_DB, "DELETE FROM legal_documents WHERE type = 'case_law';");
-    console.log(`    Removed ${parseInt(caseLawCount).toLocaleString()} case_law documents from legal_documents`);
+    console.log(
+      `    Removed ${parseInt(caseLawCount).toLocaleString()} case_law documents from legal_documents`,
+    );
   }
 
   if (parseInt(kamerstukCount) > 0) {
     sql(FREE_DB, "DELETE FROM legal_documents WHERE type = 'kamerstuk';");
-    console.log(`    Removed ${parseInt(kamerstukCount).toLocaleString()} kamerstuk documents from legal_documents`);
+    console.log(
+      `    Removed ${parseInt(kamerstukCount).toLocaleString()} kamerstuk documents from legal_documents`,
+    );
   }
 
   // Ensure db_metadata table exists and update tier
-  sql(FREE_DB, "CREATE TABLE IF NOT EXISTS db_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);");
-  sql(FREE_DB, `INSERT INTO db_metadata (key, value) VALUES ('tier', 'free') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`);
-  sql(FREE_DB, `INSERT INTO db_metadata (key, value) VALUES ('schema_version', '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`);
-  sql(FREE_DB, `INSERT INTO db_metadata (key, value) VALUES ('built_at', '${new Date().toISOString()}') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`);
-  sql(FREE_DB, `INSERT INTO db_metadata (key, value) VALUES ('builder', 'build-db-free.ts') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`);
+  sql(
+    FREE_DB,
+    'CREATE TABLE IF NOT EXISTS db_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);',
+  );
+  sql(
+    FREE_DB,
+    `INSERT INTO db_metadata (key, value) VALUES ('tier', 'free') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`,
+  );
+  sql(
+    FREE_DB,
+    `INSERT INTO db_metadata (key, value) VALUES ('schema_version', '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`,
+  );
+  sql(
+    FREE_DB,
+    `INSERT INTO db_metadata (key, value) VALUES ('built_at', '${new Date().toISOString()}') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`,
+  );
+  sql(
+    FREE_DB,
+    `INSERT INTO db_metadata (key, value) VALUES ('builder', 'build-db-free.ts') ON CONFLICT(key) DO UPDATE SET value = excluded.value;`,
+  );
 
   // Report remaining data
   const docCount = sql(FREE_DB, 'SELECT COUNT(*) FROM legal_documents;');
@@ -172,9 +210,9 @@ function buildFreeTier(): void {
 
   console.log(
     `\nFree-tier build complete.` +
-    `\n  Size: ${(fullSize / 1024 / 1024).toFixed(1)} MB -> ${(freeSize / 1024 / 1024).toFixed(1)} MB (${reduction}% reduction)` +
-    `\n  Tier: free` +
-    `\n  Output: ${FREE_DB}`
+      `\n  Size: ${(fullSize / 1024 / 1024).toFixed(1)} MB -> ${(freeSize / 1024 / 1024).toFixed(1)} MB (${reduction}% reduction)` +
+      `\n  Tier: free` +
+      `\n  Output: ${FREE_DB}`,
   );
 
   // Warn if too large for Vercel
@@ -182,8 +220,8 @@ function buildFreeTier(): void {
   if (freeSize > VERCEL_LIMIT) {
     console.warn(
       `\n  WARNING: Free-tier database is ${(freeSize / 1024 / 1024).toFixed(0)} MB.` +
-      `\n  This may be too large for Vercel Hobby plan (512 MB /tmp limit).` +
-      `\n  Consider further data trimming if deployment fails.`
+        `\n  This may be too large for Vercel Hobby plan (512 MB /tmp limit).` +
+        `\n  Consider further data trimming if deployment fails.`,
     );
   }
 }

--- a/scripts/build-db-paid.ts
+++ b/scripts/build-db-paid.ts
@@ -55,8 +55,8 @@ CREATE TABLE IF NOT EXISTS preparatory_works_full (
 CREATE INDEX IF NOT EXISTS idx_prep_works_full_prep
   ON preparatory_works_full(prep_work_id);
 
--- Agency guidance documents (paid tier)
-CREATE TABLE IF NOT EXISTS agency_guidance (
+-- Parliamentary proceedings (paid tier; kamer-level transcripts and floor speeches)
+CREATE TABLE IF NOT EXISTS parliamentary_proceedings (
   id INTEGER PRIMARY KEY,
   agency TEXT NOT NULL,
   document_id TEXT NOT NULL UNIQUE,
@@ -68,15 +68,15 @@ CREATE TABLE IF NOT EXISTS agency_guidance (
   related_statute_id TEXT REFERENCES legal_documents(id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_agency_guidance_agency
-  ON agency_guidance(agency);
-CREATE INDEX IF NOT EXISTS idx_agency_guidance_statute
-  ON agency_guidance(related_statute_id);
+CREATE INDEX IF NOT EXISTS idx_parliamentary_proceedings_agency
+  ON parliamentary_proceedings(agency);
+CREATE INDEX IF NOT EXISTS idx_parliamentary_proceedings_statute
+  ON parliamentary_proceedings(related_statute_id);
 
--- FTS5 for agency guidance search
-CREATE VIRTUAL TABLE IF NOT EXISTS agency_guidance_fts USING fts5(
+-- FTS5 for parliamentary proceedings search
+CREATE VIRTUAL TABLE IF NOT EXISTS parliamentary_proceedings_fts USING fts5(
   title, summary, full_text,
-  content='agency_guidance',
+  content='parliamentary_proceedings',
   content_rowid='id',
   tokenize='unicode61'
 );
@@ -93,7 +93,7 @@ function buildPaidTier(): void {
   if (!fs.existsSync(DB_PATH)) {
     console.error(
       `ERROR: No base database found at ${DB_PATH}\n` +
-      `Run 'npm run build:db' first to create the base database from seeds.`
+        `Run 'npm run build:db' first to create the base database from seeds.`,
     );
     process.exit(1);
   }
@@ -106,12 +106,14 @@ function buildPaidTier(): void {
   db.pragma('journal_mode = WAL');
 
   // Verify base schema exists
-  const hasLegalDocs = db.prepare(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name='legal_documents'"
-  ).get();
+  const hasLegalDocs = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='legal_documents'")
+    .get();
 
   if (!hasLegalDocs) {
-    console.error('ERROR: Base database is missing legal_documents table. Rebuild with: npm run build:db');
+    console.error(
+      'ERROR: Base database is missing legal_documents table. Rebuild with: npm run build:db',
+    );
     db.close();
     process.exit(1);
   }
@@ -126,8 +128,12 @@ function buildPaidTier(): void {
 
   // Report what's available
   const caseCount = (db.prepare('SELECT COUNT(*) as c FROM case_law').get() as { c: number }).c;
-  const provisionCount = (db.prepare('SELECT COUNT(*) as c FROM legal_provisions').get() as { c: number }).c;
-  const prepCount = (db.prepare('SELECT COUNT(*) as c FROM preparatory_works').get() as { c: number }).c;
+  const provisionCount = (
+    db.prepare('SELECT COUNT(*) as c FROM legal_provisions').get() as { c: number }
+  ).c;
+  const prepCount = (
+    db.prepare('SELECT COUNT(*) as c FROM preparatory_works').get() as { c: number }
+  ).c;
 
   console.log(`\n  Base data available:`);
   console.log(`    Provisions:        ${provisionCount.toLocaleString()}`);
@@ -135,7 +141,7 @@ function buildPaidTier(): void {
   console.log(`    Preparatory works: ${prepCount.toLocaleString()}`);
 
   // Check paid tables for data
-  const paidTables = ['case_law_full', 'preparatory_works_full', 'agency_guidance'];
+  const paidTables = ['case_law_full', 'preparatory_works_full', 'parliamentary_proceedings'];
   console.log(`\n  Paid-tier tables (stub — no data sources connected yet):`);
   for (const table of paidTables) {
     const row = db.prepare(`SELECT COUNT(*) as c FROM ${table}`).get() as { c: number };
@@ -164,15 +170,17 @@ function buildPaidTier(): void {
   const sizeAfter = fs.statSync(DB_PATH).size;
   console.log(
     `\nPaid-tier build complete.` +
-    `\n  Size: ${(sizeBefore / 1024 / 1024).toFixed(1)} MB -> ${(sizeAfter / 1024 / 1024).toFixed(1)} MB` +
-    `\n  Tier: professional` +
-    `\n  Output: ${DB_PATH}`
+      `\n  Size: ${(sizeBefore / 1024 / 1024).toFixed(1)} MB -> ${(sizeAfter / 1024 / 1024).toFixed(1)} MB` +
+      `\n  Tier: professional` +
+      `\n  Output: ${DB_PATH}`,
   );
 
   console.log(`\n  NOTE: Paid-tier tables are empty stubs. To populate them:`);
-  console.log(`    1. case_law_full -- needs full-text opinion source from rechtspraak.nl (future)`);
+  console.log(
+    `    1. case_law_full -- needs full-text opinion source from rechtspraak.nl (future)`,
+  );
   console.log(`    2. preparatory_works_full -- needs Kamerstukken full-text API (future)`);
-  console.log(`    3. agency_guidance -- needs agency document scrapers (future)`);
+  console.log(`    3. parliamentary_proceedings -- needs agency document scrapers (future)`);
 }
 
 buildPaidTier();

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -18,7 +18,7 @@ export type Capability =
   | 'eu_references'
   | 'expanded_case_law'
   | 'full_preparatory_works'
-  | 'agency_guidance';
+  | 'parliamentary_proceedings';
 
 export type Tier = 'free' | 'professional' | 'unknown';
 
@@ -39,13 +39,13 @@ const CAPABILITY_TABLES: Record<Capability, string> = {
   eu_references: 'eu_references',
   expanded_case_law: 'case_law_full',
   full_preparatory_works: 'preparatory_works_full',
-  agency_guidance: 'agency_guidance',
+  parliamentary_proceedings: 'parliamentary_proceedings',
 };
 
 const PROFESSIONAL_CAPABILITIES: Capability[] = [
   'expanded_case_law',
   'full_preparatory_works',
-  'agency_guidance',
+  'parliamentary_proceedings',
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -60,8 +60,9 @@ export function detectCapabilities(db: InstanceType<typeof Database>): Set<Capab
   const capabilities = new Set<Capability>();
 
   const tables = new Set(
-    (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[])
-      .map(r => r.name)
+    (
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]
+    ).map((r) => r.name),
   );
 
   for (const [capability, table] of Object.entries(CAPABILITY_TABLES)) {
@@ -85,13 +86,16 @@ export function readDbMetadata(db: InstanceType<typeof Database>): DbMetadata {
   };
 
   try {
-    const hasTable = db.prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='db_metadata'"
-    ).get();
+    const hasTable = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='db_metadata'")
+      .get();
 
     if (!hasTable) return defaults;
 
-    const rows = db.prepare('SELECT key, value FROM db_metadata').all() as { key: string; value: string }[];
+    const rows = db.prepare('SELECT key, value FROM db_metadata').all() as {
+      key: string;
+      value: string;
+    }[];
     const meta = { ...defaults };
 
     for (const row of rows) {
@@ -135,8 +139,8 @@ export function upgradeMessage(feature: string): string {
  * Useful for guarding tool execution against missing tables on the free tier.
  */
 export function hasTable(db: InstanceType<typeof Database>, tableName: string): boolean {
-  const row = db.prepare(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name=?"
-  ).get(tableName);
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+    .get(tableName);
   return row != null;
 }

--- a/src/tools/search-parliamentary-proceedings.ts
+++ b/src/tools/search-parliamentary-proceedings.ts
@@ -45,7 +45,7 @@ function runFtsSearch(
   const conditions: string[] = [];
   const params: (string | number)[] = [];
 
-  conditions.push('agency_guidance_fts MATCH ?');
+  conditions.push('parliamentary_proceedings_fts MATCH ?');
   params.push(ftsQuery);
 
   if (dateFrom) {
@@ -66,14 +66,14 @@ function runFtsSearch(
       ag.title,
       ag.summary,
       ag.issued_date,
-      snippet(agency_guidance_fts, 2, '**', '**', '...', 32) AS snippet,
-      bm25(agency_guidance_fts) AS relevance,
+      snippet(parliamentary_proceedings_fts, 2, '**', '**', '...', 32) AS snippet,
+      bm25(parliamentary_proceedings_fts) AS relevance,
       ag.url,
       ag.related_statute_id
-    FROM agency_guidance_fts
-    JOIN agency_guidance AS ag ON agency_guidance_fts.rowid = ag.id
+    FROM parliamentary_proceedings_fts
+    JOIN parliamentary_proceedings AS ag ON parliamentary_proceedings_fts.rowid = ag.id
     ${whereClause}
-    ORDER BY bm25(agency_guidance_fts)
+    ORDER BY bm25(parliamentary_proceedings_fts)
     LIMIT ?
   `;
   params.push(limit);
@@ -117,8 +117,8 @@ export async function searchParliamentaryProceedings(
   db: Database,
   input: SearchParliamentaryProceedingsInput,
 ): Promise<ToolResponse<SearchParliamentaryProceedingsResult[]>> {
-  // Guard: check that agency_guidance table exists (missing on free tier)
-  if (!hasTable(db, 'agency_guidance')) {
+  // Guard: check that parliamentary_proceedings table exists (missing on free tier)
+  if (!hasTable(db, 'parliamentary_proceedings')) {
     return {
       results: [],
       _metadata: generateResponseMetadata(db),

--- a/src/utils/runtime-db.ts
+++ b/src/utils/runtime-db.ts
@@ -2,6 +2,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import Database from '@ansvar/mcp-sqlite';
+
 const RUNTIME_DB_DIR_ENV_VAR = 'DUTCH_LAW_RUNTIME_DB_DIR';
 const RUNTIME_DB_FILENAME = 'database.db';
 const RUNTIME_DB_STAMP_FILENAME = 'source.json';
@@ -60,6 +62,64 @@ function removeStaleLockDir(dbPath: string): void {
   fs.rmSync(`${dbPath}.lock`, { recursive: true, force: true });
 }
 
+/**
+ * Rename legacy agency_guidance table + FTS to parliamentary_proceedings (#54).
+ *
+ * Idempotent: only fires when the legacy table is present. SQLite ALTER TABLE
+ * RENAME does not update FTS5 virtual tables that reference the old name via
+ * `content=`, so the FTS shadow is dropped and recreated under the new name
+ * and repopulated from the renamed data table.
+ */
+export function migrateAgencyGuidanceRename(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    // Read the schema via exec-friendly path. Calling .all() on a Statement
+    // forces it through to the iterator and lets node-sqlite3-wasm release
+    // the read transaction before subsequent DDL.
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agency_guidance'")
+      .all() as { name: string }[];
+    if (rows.length === 0) return;
+
+    // Drop dependents first so the rename does not have to update triggers
+    // that reference the old name. Each statement runs in its own implicit
+    // transaction; the block of changes runs sequentially. node-sqlite3-wasm
+    // does not always handle BEGIN ... COMMIT across an FTS5 rename + trigger
+    // recreate cleanly, so the rename is split into discrete statements and
+    // FTS rebuild lives in a single INSERT.
+    db.exec('DROP TRIGGER IF EXISTS agency_guidance_ai');
+    db.exec('DROP TRIGGER IF EXISTS agency_guidance_ad');
+    db.exec('DROP TABLE IF EXISTS agency_guidance_fts');
+    db.exec('ALTER TABLE agency_guidance RENAME TO parliamentary_proceedings');
+    db.exec(
+      `CREATE VIRTUAL TABLE parliamentary_proceedings_fts USING fts5(
+        title, summary, full_text,
+        content='parliamentary_proceedings',
+        content_rowid='id',
+        tokenize='unicode61'
+      )`,
+    );
+    db.exec(
+      `CREATE TRIGGER parliamentary_proceedings_ai AFTER INSERT ON parliamentary_proceedings BEGIN
+        INSERT INTO parliamentary_proceedings_fts(rowid, title, summary, full_text)
+        VALUES (new.id, new.title, new.summary, new.full_text);
+      END`,
+    );
+    db.exec(
+      `CREATE TRIGGER parliamentary_proceedings_ad AFTER DELETE ON parliamentary_proceedings BEGIN
+        INSERT INTO parliamentary_proceedings_fts(parliamentary_proceedings_fts, rowid, title, summary, full_text)
+        VALUES ('delete', old.id, old.title, old.summary, old.full_text);
+      END`,
+    );
+    db.exec(
+      `INSERT INTO parliamentary_proceedings_fts(rowid, title, summary, full_text)
+        SELECT id, title, summary, full_text FROM parliamentary_proceedings`,
+    );
+  } finally {
+    db.close();
+  }
+}
+
 export function prepareRuntimeDatabase(
   sourcePath: string,
   options: PrepareRuntimeDatabaseOptions = {},
@@ -83,5 +143,6 @@ export function prepareRuntimeDatabase(
   }
 
   removeStaleLockDir(dbPath);
+  migrateAgencyGuidanceRename(dbPath);
   return dbPath;
 }

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -28,7 +28,7 @@ function createPaidTierDb(): InstanceType<typeof Database> {
   db.exec(`
     CREATE TABLE case_law_full (id INTEGER PRIMARY KEY, full_text TEXT);
     CREATE TABLE preparatory_works_full (id INTEGER PRIMARY KEY, full_text TEXT);
-    CREATE TABLE agency_guidance (id INTEGER PRIMARY KEY, guidance TEXT);
+    CREATE TABLE parliamentary_proceedings (id INTEGER PRIMARY KEY, guidance TEXT);
   `);
   return db;
 }
@@ -68,7 +68,7 @@ describe('detectCapabilities', () => {
 
     expect(caps.has('expanded_case_law')).toBe(false);
     expect(caps.has('full_preparatory_works')).toBe(false);
-    expect(caps.has('agency_guidance')).toBe(false);
+    expect(caps.has('parliamentary_proceedings')).toBe(false);
 
     expect(caps.size).toBe(3);
   });
@@ -82,7 +82,7 @@ describe('detectCapabilities', () => {
     expect(caps.has('eu_references')).toBe(true);
     expect(caps.has('expanded_case_law')).toBe(true);
     expect(caps.has('full_preparatory_works')).toBe(true);
-    expect(caps.has('agency_guidance')).toBe(true);
+    expect(caps.has('parliamentary_proceedings')).toBe(true);
 
     expect(caps.size).toBe(6);
   });
@@ -180,7 +180,7 @@ describe('isProfessionalCapability', () => {
   it('should return true for paid capabilities', () => {
     expect(isProfessionalCapability('expanded_case_law')).toBe(true);
     expect(isProfessionalCapability('full_preparatory_works')).toBe(true);
-    expect(isProfessionalCapability('agency_guidance')).toBe(true);
+    expect(isProfessionalCapability('parliamentary_proceedings')).toBe(true);
   });
 
   it('should return false for free capabilities', () => {

--- a/tests/fixtures/test-db.ts
+++ b/tests/fixtures/test-db.ts
@@ -168,7 +168,7 @@ CREATE TRIGGER prep_works_ad AFTER DELETE ON preparatory_works BEGIN
   VALUES ('delete', old.id, old.title, old.summary);
 END;
 
-CREATE TABLE agency_guidance (
+CREATE TABLE parliamentary_proceedings (
   id INTEGER PRIMARY KEY,
   agency TEXT NOT NULL,
   document_id TEXT,
@@ -180,20 +180,20 @@ CREATE TABLE agency_guidance (
   related_statute_id TEXT
 );
 
-CREATE VIRTUAL TABLE agency_guidance_fts USING fts5(
+CREATE VIRTUAL TABLE parliamentary_proceedings_fts USING fts5(
   title, summary, full_text,
-  content='agency_guidance',
+  content='parliamentary_proceedings',
   content_rowid='id',
   tokenize='unicode61'
 );
 
-CREATE TRIGGER agency_guidance_ai AFTER INSERT ON agency_guidance BEGIN
-  INSERT INTO agency_guidance_fts(rowid, title, summary, full_text)
+CREATE TRIGGER parliamentary_proceedings_ai AFTER INSERT ON parliamentary_proceedings BEGIN
+  INSERT INTO parliamentary_proceedings_fts(rowid, title, summary, full_text)
   VALUES (new.id, new.title, new.summary, new.full_text);
 END;
 
-CREATE TRIGGER agency_guidance_ad AFTER DELETE ON agency_guidance BEGIN
-  INSERT INTO agency_guidance_fts(agency_guidance_fts, rowid, title, summary, full_text)
+CREATE TRIGGER parliamentary_proceedings_ad AFTER DELETE ON parliamentary_proceedings BEGIN
+  INSERT INTO parliamentary_proceedings_fts(parliamentary_proceedings_fts, rowid, title, summary, full_text)
   VALUES ('delete', old.id, old.title, old.summary, old.full_text);
 END;
 
@@ -899,7 +899,7 @@ export function createTestDatabase(): InstanceType<typeof Database> {
 
     // Agency guidance (parliamentary proceedings)
     const insertGuidance = db.prepare(
-      `INSERT INTO agency_guidance (agency, document_id, title, summary, full_text, issued_date, url, related_statute_id)
+      `INSERT INTO parliamentary_proceedings (agency, document_id, title, summary, full_text, issued_date, url, related_statute_id)
        VALUES (@agency, @document_id, @title, @summary, @full_text, @issued_date, @url, @related_statute_id)`,
     );
     for (const ag of SAMPLE_AGENCY_GUIDANCE) {

--- a/tests/utils/runtime-db.test.ts
+++ b/tests/utils/runtime-db.test.ts
@@ -2,8 +2,9 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import Database from '@ansvar/mcp-sqlite';
 
-import { prepareRuntimeDatabase } from '../../src/utils/runtime-db.js';
+import { migrateAgencyGuidanceRename, prepareRuntimeDatabase } from '../../src/utils/runtime-db.js';
 
 const cleanupPaths: string[] = [];
 
@@ -13,6 +14,48 @@ afterEach(() => {
   }
 });
 
+const LEGACY_SCHEMA_SQL = `
+CREATE TABLE agency_guidance (
+  id INTEGER PRIMARY KEY,
+  agency TEXT NOT NULL,
+  document_id TEXT,
+  title TEXT,
+  summary TEXT,
+  full_text TEXT,
+  issued_date TEXT,
+  url TEXT,
+  related_statute_id TEXT
+);
+CREATE VIRTUAL TABLE agency_guidance_fts USING fts5(
+  title, summary, full_text,
+  content='agency_guidance',
+  content_rowid='id',
+  tokenize='unicode61'
+);
+CREATE TRIGGER agency_guidance_ai AFTER INSERT ON agency_guidance BEGIN
+  INSERT INTO agency_guidance_fts(rowid, title, summary, full_text)
+  VALUES (new.id, new.title, new.summary, new.full_text);
+END;
+CREATE TRIGGER agency_guidance_ad AFTER DELETE ON agency_guidance BEGIN
+  INSERT INTO agency_guidance_fts(agency_guidance_fts, rowid, title, summary, full_text)
+  VALUES ('delete', old.id, old.title, old.summary, old.full_text);
+END;
+INSERT INTO agency_guidance (agency, title, summary, full_text)
+VALUES ('tweede-kamer', 'Legacy debate transcript', 'Migration corpus row',
+        'A row that existed under the legacy agency_guidance schema.');
+`;
+
+function buildLegacyAgencyGuidanceDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.exec(LEGACY_SCHEMA_SQL);
+  db.close();
+}
+
+function makeEmptySqliteDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.close();
+}
+
 describe('prepareRuntimeDatabase', () => {
   it('copies the source database into the runtime directory and clears stale lock dirs', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dutch-law-runtime-test-'));
@@ -20,13 +63,98 @@ describe('prepareRuntimeDatabase', () => {
 
     const sourcePath = path.join(tempRoot, 'source.db');
     const runtimeDir = path.join(tempRoot, 'runtime');
-    fs.writeFileSync(sourcePath, 'test-db', 'utf-8');
+    makeEmptySqliteDb(sourcePath);
     fs.mkdirSync(path.join(runtimeDir, 'database.db.lock'), { recursive: true });
 
     const runtimePath = prepareRuntimeDatabase(sourcePath, { runtimeDir });
 
     expect(runtimePath).toBe(path.join(runtimeDir, 'database.db'));
-    expect(fs.readFileSync(runtimePath, 'utf-8')).toBe('test-db');
+    expect(fs.existsSync(runtimePath)).toBe(true);
     expect(fs.existsSync(`${runtimePath}.lock`)).toBe(false);
+  });
+});
+
+describe('migrateAgencyGuidanceRename (#54)', () => {
+  it('renames legacy agency_guidance to parliamentary_proceedings, preserving rows', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dutch-law-migrate-test-'));
+    cleanupPaths.push(tempRoot);
+    const dbPath = path.join(tempRoot, 'legacy.db');
+    buildLegacyAgencyGuidanceDb(dbPath);
+
+    migrateAgencyGuidanceRename(dbPath);
+
+    const db = new Database(dbPath);
+    try {
+      const legacyTable = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agency_guidance'")
+        .get();
+      expect(legacyTable).toBeUndefined();
+
+      const newTable = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='parliamentary_proceedings'",
+        )
+        .get();
+      expect(newTable).toBeDefined();
+
+      const ftsTable = db
+        .prepare("SELECT name FROM sqlite_master WHERE name='parliamentary_proceedings_fts'")
+        .get();
+      expect(ftsTable).toBeDefined();
+
+      const rowCount = db.prepare('SELECT COUNT(*) as c FROM parliamentary_proceedings').get() as {
+        c: number;
+      };
+      expect(rowCount.c).toBe(1);
+
+      const ftsHit = db
+        .prepare(
+          'SELECT rowid FROM parliamentary_proceedings_fts WHERE parliamentary_proceedings_fts MATCH ?',
+        )
+        .all('legacy debate') as { rowid: number }[];
+      expect(ftsHit.length).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('is a no-op when agency_guidance is absent (idempotent)', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dutch-law-migrate-test-'));
+    cleanupPaths.push(tempRoot);
+    const dbPath = path.join(tempRoot, 'fresh.db');
+    makeEmptySqliteDb(dbPath);
+
+    expect(() => migrateAgencyGuidanceRename(dbPath)).not.toThrow();
+
+    const db = new Database(dbPath);
+    try {
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+        name: string;
+      }[];
+      expect(tables.find((t) => t.name === 'parliamentary_proceedings')).toBeUndefined();
+      expect(tables.find((t) => t.name === 'agency_guidance')).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('is safe to run twice on the same legacy DB', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dutch-law-migrate-test-'));
+    cleanupPaths.push(tempRoot);
+    const dbPath = path.join(tempRoot, 'legacy.db');
+    buildLegacyAgencyGuidanceDb(dbPath);
+
+    migrateAgencyGuidanceRename(dbPath);
+    expect(() => migrateAgencyGuidanceRename(dbPath)).not.toThrow();
+
+    const db = new Database(dbPath);
+    try {
+      const rowCount = db.prepare('SELECT COUNT(*) as c FROM parliamentary_proceedings').get() as {
+        c: number;
+      };
+      expect(rowCount.c).toBe(1);
+    } finally {
+      db.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #54. Renames the misnamed \`agency_guidance\` table to \`parliamentary_proceedings\` since the contents are Tweede Kamer / Eerste Kamer verbatim transcripts, not generic agency guidance.

## Mechanical rename

- \`scripts/build-db-paid.ts\`, \`scripts/build-db-free.ts\` — canonical schema
- \`src/tools/search-parliamentary-proceedings.ts\` — tool SQL queries the new table name
- \`src/capabilities.ts\` — \`Capability\` union type renamed; \`CAPABILITY_TABLES\` and \`PROFESSIONAL_CAPABILITIES\` updated
- \`tests/capabilities.test.ts\`, \`tests/fixtures/test-db.ts\` — follow

## Runtime migration (new — \`src/utils/runtime-db.ts\`)

Idempotent migration runs at every server startup via \`prepareRuntimeDatabase\`. If the legacy \`agency_guidance\` table is present:
1. Drop legacy FTS5 + INSERT/DELETE triggers (FTS5 \`content=\` references cannot follow ALTER TABLE RENAME).
2. \`ALTER TABLE agency_guidance RENAME TO parliamentary_proceedings\`.
3. Create new FTS5 + triggers using the new name.
4. Repopulate FTS index from the renamed data table.

Once applied, the migration is a no-op on subsequent startups.

## Side fix — type pollution

This PR also adds \`@types/better-sqlite3\` as a devDependency. Pre-existing: \`scripts/build-db-paid.ts\` uses better-sqlite3 directly but the types package was never added, so eslint flagged 58 \`no-unsafe-call\` errors on every method call. This was tolerated because most fleet PRs don't touch that file; the pre-commit hook only runs on staged files. The Phase 5E rename touches build-db-paid.ts, so the missing types blocked commit. Adding the types is the durable fix.

## Verification

- \`npm test\` — 335/335.
- \`npm run build:db\` — successful (free-tier schema clean).
- \`npx tsc --noEmit\` — clean.
- \`npx eslint src/ tests/ scripts/\` — clean (after \`@types/better-sqlite3\`).

### Migration tests in \`tests/utils/runtime-db.test.ts\`
- Legacy schema → migrated table + FTS, rows preserved (\`SELECT COUNT(*)\` correct, FTS5 MATCH still finds the legacy row).
- No-op when legacy table absent.
- Idempotent across two runs.

## Plan reference

Phase 5E of \`docs/superpowers/plans/2026-05-07-dutch-law-mcp-golden-state.md\` in arch-docs (PR #401, merged).