### PR TITLE
fix(Dockerfile): prefer download:db over build:db (unbreak GHCR build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,24 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# curl/gzip needed by download-db.sh
+RUN apk add --no-cache curl gzip
+
 COPY package*.json ./
 RUN npm ci --ignore-scripts && npm cache clean --force
 COPY tsconfig.json ./
 COPY src/ ./src/
-COPY scripts/ ./scripts/
+COPY scripts/download-db.sh ./scripts/download-db.sh
 RUN npm run build
 COPY data/ ./data/
-RUN if npm run 2>/dev/null | grep -q "build:db"; then npm run build:db; fi
+# Provision database. Prefer download:db (ship-via-release pattern: the
+# pre-built DB is uploaded to GitHub Releases and not committed). Fall back
+# to build:db if download:db isn't defined (seeds-in-repo pattern).
+RUN if npm run 2>/dev/null | grep -q "^  download:db"; then \
+      npm run download:db; \
+    elif npm run 2>/dev/null | grep -q "^  build:db"; then \
+      npm run build:db; \
+    fi
 
 FROM node:20-alpine AS runtime
 


### PR DESCRIPTION
## Summary

PR #88 (golden-standard treatment) rewrote the Dockerfile from the canonical template. The new template assumed all auto_ingested MCPs use the seeds-in-repo pattern (`data/seed/*.json` committed; `build:db` produces DB in-CI). Dutch-law-mcp uses the **ship-via-release** pattern: seeds are 100MB+ and NOT committed; the pre-built `database.db` ships as a GitHub Release asset and is pulled by `scripts/download-db.sh`.

The post-merge GHCR build crashed with:
\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/app/scripts/import-eurlex-documents.ts' imported from /app/
\`\`\`
because `.dockerignore` deliberately excludes `scripts/` (only `download-db.sh` is allow-listed) but the Dockerfile still tried to run `build:db`, which chains `import-eurlex-documents.ts` — never copied into the image.

## Fix

- Builder stage now copies only `scripts/download-db.sh` (matches `.dockerignore` allow-list)
- New "Provision database" RUN step:
  - If `download:db` exists → use it (ship-via-release)
  - Else if `build:db` exists → use it (seeds-in-repo)
  - Else no-op (native-curated)
- Added `curl`/`gzip` to builder for `download-db.sh` dependencies

Symmetric with the CI workflow change in commit 2090f31 (`.github/workflows/ci.yml` "Provision database" step).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, "Publish GHCR Image" workflow succeeds on main
- [ ] Watchtower swaps `:latest` on Hetzner
- [ ] Container health check passes; `docker exec law-dutch wget -qO- http://localhost:3000/health` returns 200

## Fleet-wide

The canonical `apply-golden-standard.sh` template should ship this Dockerfile shape — tracked as fleet hygiene follow-up. This PR fixes Dutch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)