### PR TITLE
fix(ingest): emit in_force_date from BWB toestand@inwerkingtreding (closes #86)

### DIFF
--- a/scripts/ingest-bwb.ts
+++ b/scripts/ingest-bwb.ts
@@ -185,6 +185,7 @@ async function fetchAndParseBWB(
   toestandUrl?: string,
 ): Promise<{
   title: string;
+  in_force_date?: string;
   provisions: Array<{
     provision_ref: string;
     book?: string;
@@ -209,6 +210,7 @@ async function fetchAndParseBWB(
 
     return {
       title: parsed.title,
+      in_force_date: parsed.in_force_date,
       provisions: parsed.provisions,
     };
   } catch (err) {
@@ -232,6 +234,7 @@ function writeSeedFile(
     title?: string;
     content: string;
   }>,
+  options: { in_force_date?: string } = {},
 ): void {
   const seedData = {
     documents: [
@@ -240,6 +243,7 @@ function writeSeedFile(
         type: 'statute' as const,
         title,
         status: 'in_force',
+        ...(options.in_force_date ? { in_force_date: options.in_force_date } : {}),
         url: `https://wetten.overheid.nl/${bwbId}`,
       },
     ],
@@ -329,7 +333,9 @@ async function main(): Promise<void> {
     const result = await fetchAndParseBWB(record.bwbId, record.toestandUrl);
 
     if (result && result.provisions.length > 0) {
-      writeSeedFile(record.bwbId, result.title || record.title, result.provisions);
+      writeSeedFile(record.bwbId, result.title || record.title, result.provisions, {
+        in_force_date: result.in_force_date,
+      });
       console.log(`    Parsed ${result.provisions.length} provisions`);
       successCount++;
     } else if (result) {

--- a/src/parsers/bwb-xml-parser.ts
+++ b/src/parsers/bwb-xml-parser.ts
@@ -11,6 +11,12 @@ function attrToString(val: unknown): string {
 export interface ParsedStatute {
   bwb_id: string;
   title: string;
+  /**
+   * ISO-8601 in-force date from the BWB `toestand@inwerkingtreding` attribute
+   * (e.g. "2018-05-25"). Undefined for legacy/test fixtures that don't include
+   * the `<toestand>` wrapper.
+   */
+  in_force_date?: string;
   provisions: ParsedProvision[];
 }
 
@@ -283,10 +289,19 @@ export function parseBwbXml(xml: string): ParsedStatute {
 
   let wetgeving: Record<string, unknown> | undefined;
   let bwbId = '';
+  let inForceDate: string | undefined;
 
   if (toestand) {
     // Real toestand XML: toestand > wetgeving
     bwbId = attrToString(toestand['@_bwb-id']);
+    // The toestand root carries an `inwerkingtreding="YYYY-MM-DD"` attribute
+    // recording when this versioned text became in force. Capture it so the
+    // ingest pipeline can populate legal_documents.in_force_date — the source
+    // of effective_date in citation envelopes (see get-provision.ts:59,81,121).
+    const rawDate = attrToString(toestand['@_inwerkingtreding']).trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(rawDate)) {
+      inForceDate = rawDate;
+    }
     wetgeving = toestand['wetgeving'] as Record<string, unknown> | undefined;
   } else {
     // Legacy/test format: wet-besluit > wetgeving
@@ -298,7 +313,7 @@ export function parseBwbXml(xml: string): ParsedStatute {
   }
 
   if (!wetgeving) {
-    return { bwb_id: bwbId, title: '', provisions: [] };
+    return { bwb_id: bwbId, title: '', in_force_date: inForceDate, provisions: [] };
   }
 
   // Extract BWB-ID (may be on wetgeving if not on toestand)
@@ -327,12 +342,12 @@ export function parseBwbXml(xml: string): ParsedStatute {
     wetgeving['regeling-tekst'];
 
   if (!contentRoot || typeof contentRoot !== 'object') {
-    return { bwb_id: bwbId, title, provisions: [] };
+    return { bwb_id: bwbId, title, in_force_date: inForceDate, provisions: [] };
   }
 
   // Collect all provisions by traversing the hierarchy
   const provisions: ParsedProvision[] = [];
   collectArtikels(contentRoot as Record<string, unknown>, {}, provisions);
 
-  return { bwb_id: bwbId, title, provisions };
+  return { bwb_id: bwbId, title, in_force_date: inForceDate, provisions };
 }

--- a/tests/parsers/bwb-xml-parser.test.ts
+++ b/tests/parsers/bwb-xml-parser.test.ts
@@ -322,7 +322,9 @@ describe('parseBwbXml', () => {
     it('should not prefix with lid number for direct al', () => {
       const result = parseBwbXml(DIRECT_AL_XML);
       // Direct al has no lid prefix
-      expect(result.provisions[0].content).toBe('Deze wet is van toepassing op alle rechtsverhoudingen.');
+      expect(result.provisions[0].content).toBe(
+        'Deze wet is van toepassing op alle rechtsverhoudingen.',
+      );
     });
   });
 
@@ -342,6 +344,43 @@ describe('parseBwbXml', () => {
       const result = parseBwbXml(MULTIPLE_ARTICLES_XML);
       expect(result.provisions[0].title).toBe('Onrechtmatige daad');
       expect(result.provisions[1].title).toBe('Toerekening');
+    });
+  });
+
+  describe('in_force_date extraction', () => {
+    const TOESTAND_WITH_DATE = `<?xml version="1.0" encoding="UTF-8"?>
+<toestand bwb-id="BWBR0040940" inwerkingtreding="2018-05-25">
+  <wetgeving bwb-id="BWBR0040940">
+    <intitule>Uitvoeringswet AVG</intitule>
+    <wet-besluit>
+      <wettekst>
+        <artikel bwb-ng-variabel-deel="/join/id/regdata/BWBR0040940/2018-05-25/0/artikel_5">
+          <kop><label>Artikel</label><nr>5</nr></kop>
+          <al>Test content.</al>
+        </artikel>
+      </wettekst>
+    </wet-besluit>
+  </wetgeving>
+</toestand>`;
+
+    it('extracts inwerkingtreding attribute from toestand root', () => {
+      const result = parseBwbXml(TOESTAND_WITH_DATE);
+      expect(result.in_force_date).toBe('2018-05-25');
+      expect(result.bwb_id).toBe('BWBR0040940');
+    });
+
+    it('omits in_force_date for legacy wet-besluit-only fixtures', () => {
+      const result = parseBwbXml(BW_ARTICLE_XML);
+      expect(result.in_force_date).toBeUndefined();
+    });
+
+    it('ignores malformed inwerkingtreding values', () => {
+      const xml = TOESTAND_WITH_DATE.replace(
+        'inwerkingtreding="2018-05-25"',
+        'inwerkingtreding="bogus"',
+      );
+      const result = parseBwbXml(xml);
+      expect(result.in_force_date).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Live gateway probes were returning citations with an empty `effective_date` field even though the field IS plumbed end-to-end. Investigation showed the SQL chain works (\`SELECT d.in_force_date AS effective_date\` → citation envelope) but the column was always NULL because \`ingest-bwb.ts\` never populated it.

Inspected a sample BWB XML (BWBR0040940 / Uitvoeringswet AVG) and found:

\`\`\`xml
<toestand bwb-id="BWBR0040940" inwerkingtreding="2018-05-25">
\`\`\`

The root \`<toestand>\` element carries the in-force date as an attribute. This PR captures it through the existing pipeline.

## Changes

- **\`src/parsers/bwb-xml-parser.ts\`**: \`ParsedStatute\` gains optional \`in_force_date\`. \`parseBwbXml\` extracts \`toestand@inwerkingtreding\`, validates ISO-8601 (\`YYYY-MM-DD\`), and ignores malformed values.
- **\`scripts/ingest-bwb.ts\`**: \`fetchAndParseBWB\` passes the date through. \`writeSeedFile\` writes it into the document seed JSON (additive — old seeds still validate).
- **\`build-db.ts\`**: no change needed — already reads \`in_force_date\` from seeds into \`legal_documents.in_force_date\` at line 510.
- **\`get_provision.ts\` / \`search-legislation.ts\`**: no change needed — already SELECT \`d.in_force_date AS effective_date\`.
- **Tests**: 3 new unit tests for parser \`in_force_date\` extraction (positive, omitted-for-legacy, malformed-rejected). 338 total tests pass.

## What this delivers

After this PR lands + the next ingestion run rebuilds the DB + new release ships, customer citation envelopes will return populated \`effective_date\` values:

\`\`\`json
{
  "source": "BWBR0040940",
  "article": "5",
  "source_url": "https://wetten.overheid.nl/BWBR0040940",
  "effective_date": "2018-05-25"   // <-- was always "" before
}
\`\`\`

Companion to #84 (citation envelope shape) — that fixed the shape; this fills the value.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — 338/338 pass
- [ ] CI green on this PR
- [ ] After merge: scheduled ingestion run picks up new dates
- [ ] After new release: gateway probe of \`get_provision(law=AVG, article=5)\` returns \`effective_date=\"2018-05-25\"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)