### PR TITLE
fix(scripts): use sh instead of bash for download:db (alpine compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:contract": "vitest run --config vitest.contract.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "download:db": "bash scripts/download-db.sh",
+    "download:db": "sh scripts/download-db.sh",
     "drift:detect": "tsx scripts/drift-detect.ts",
     "validate": "npm run lint && npm test && npm run test:contract",
     "ingest": "tsx scripts/ingest-bwb.ts",


### PR DESCRIPTION
## Summary

Hotfix to main: \`download:db\` invoked \`bash\` which isn't in node:20-alpine. GHCR publish run 25813277380 crashed with \`sh: bash: not found\`.

Script shebang is already \`#!/bin/sh\` and body is POSIX-compatible, so this is a safe one-line change. Targets main directly because this blocks prod image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)