### PR TITLE
release: v1.2.2 — effective_date populated for all 3251 statutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansvar/dutch-law-mcp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "mcpName": "eu.ansvar/dutch-law-mcp",
   "description": "Production-grade Dutch legal research MCP server with comprehensive statute coverage and EU law cross-references",
   "type": "module",

--- a/scripts/ingest-single-bwb.ts
+++ b/scripts/ingest-single-bwb.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * One-off targeted ingestion — fetches a small list of BWB IDs directly.
+ *
+ * Bypasses the SRU discovery phase (which enumerates ~24K records over
+ * ~8 minutes) by going straight to BWB XML for specific known statutes.
+ * Used to validate parser/ingest changes end-to-end before kicking off a
+ * full unlimited run.
+ *
+ * Usage:
+ *   tsx scripts/ingest-single-bwb.ts BWBR0040940 BWBR0001854 ...
+ *
+ * Side-effect: writes data/seed/<bwbId>.json for each successful fetch.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseBwbXml } from '../src/parsers/bwb-xml-parser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SEED_DIR = path.resolve(__dirname, '..', 'data', 'seed');
+const BWB_XML_BASE = 'https://repository.officiele-overheidspublicaties.nl/bwb';
+
+interface SeedDoc {
+  id: string;
+  type: 'statute';
+  title: string;
+  status: string;
+  in_force_date?: string;
+  url: string;
+}
+
+async function fetchBwb(bwbId: string): Promise<void> {
+  const url = `${BWB_XML_BASE}/${bwbId}/xml/${bwbId}.xml`;
+  console.log(`Fetching ${bwbId} from ${url}`);
+
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) {
+    console.error(`  HTTP ${res.status} — skipping`);
+    return;
+  }
+  const xml = await res.text();
+  const parsed = parseBwbXml(xml);
+  if (!parsed.bwb_id) {
+    console.error(`  No bwb_id parsed — skipping`);
+    return;
+  }
+  if (parsed.provisions.length === 0) {
+    console.error(`  No provisions — skipping`);
+    return;
+  }
+
+  const doc: SeedDoc = {
+    id: parsed.bwb_id,
+    type: 'statute',
+    title: parsed.title,
+    status: 'in_force',
+    url: `https://wetten.overheid.nl/${parsed.bwb_id}`,
+  };
+  if (parsed.in_force_date) {
+    doc.in_force_date = parsed.in_force_date;
+  }
+
+  const seedData = {
+    documents: [doc],
+    provisions: parsed.provisions.map((p) => ({
+      document_id: parsed.bwb_id,
+      provision_ref: p.provision_ref,
+      book: p.book,
+      chapter: p.chapter,
+      section: p.section,
+      article: p.article,
+      title: p.title,
+      content: p.content,
+    })),
+  };
+
+  fs.mkdirSync(SEED_DIR, { recursive: true });
+  const filePath = path.join(SEED_DIR, `${parsed.bwb_id}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(seedData, null, 2), 'utf-8');
+  console.log(
+    `  OK — wrote ${filePath} (${parsed.provisions.length} provisions, in_force_date=${parsed.in_force_date ?? '(none)'})`,
+  );
+}
+
+async function main(): Promise<void> {
+  const ids = process.argv.slice(2);
+  if (ids.length === 0) {
+    console.error('Usage: tsx scripts/ingest-single-bwb.ts BWBR0040940 [BWBR... ...]');
+    process.exit(1);
+  }
+  for (const id of ids) {
+    await fetchBwb(id);
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+void main();

--- a/scripts/ingest-single-bwb.ts
+++ b/scripts/ingest-single-bwb.ts
@@ -32,13 +32,36 @@ interface SeedDoc {
   url: string;
 }
 
+async function fetchWithRetry(url: string, maxAttempts = 4): Promise<Response | null> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(url, { redirect: 'follow' });
+      if (res.ok) return res;
+      // Retry only on 5xx / 429 / network-class statuses
+      if (res.status >= 500 || res.status === 429) {
+        await new Promise((r) => setTimeout(r, 1000 * attempt));
+        continue;
+      }
+      // 4xx (except 429) — non-retryable
+      return res;
+    } catch (err) {
+      lastErr = err;
+      // Exponential-ish backoff: 1s, 2s, 4s, 8s
+      await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+    }
+  }
+  console.error(`  Retries exhausted for ${url}: ${String(lastErr)}`);
+  return null;
+}
+
 async function fetchBwb(bwbId: string): Promise<void> {
   const url = `${BWB_XML_BASE}/${bwbId}/xml/${bwbId}.xml`;
   console.log(`Fetching ${bwbId} from ${url}`);
 
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok) {
-    console.error(`  HTTP ${res.status} — skipping`);
+  const res = await fetchWithRetry(url);
+  if (!res || !res.ok) {
+    console.error(`  HTTP ${res?.status ?? 'no-response'} — skipping`);
     return;
   }
   const xml = await res.text();
@@ -86,15 +109,63 @@ async function fetchBwb(bwbId: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  const ids = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  let concurrency = 1;
+  const ids: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--concurrency' && i + 1 < args.length) {
+      concurrency = Math.max(1, parseInt(args[i + 1], 10) || 1);
+      i++;
+    } else {
+      ids.push(args[i]);
+    }
+  }
   if (ids.length === 0) {
-    console.error('Usage: tsx scripts/ingest-single-bwb.ts BWBR0040940 [BWBR... ...]');
+    console.error(
+      'Usage: tsx scripts/ingest-single-bwb.ts [--concurrency N] BWBR0040940 [BWBR... ...]',
+    );
     process.exit(1);
   }
-  for (const id of ids) {
-    await fetchBwb(id);
-    await new Promise((r) => setTimeout(r, 500));
+
+  if (concurrency === 1) {
+    for (const id of ids) {
+      await fetchBwb(id);
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return;
   }
+
+  // Worker-pool concurrency. Keep N inflight at once, push the next one
+  // into the queue as each finishes. Lets the long fetches/parses for
+  // big statutes (e.g. Wetboek van Strafrecht has 670+ provisions) overlap
+  // with smaller ones, cutting wall-clock time ~Nx for N concurrent workers.
+  const queue = [...ids];
+  let active = 0;
+  let done = 0;
+  await new Promise<void>((resolve) => {
+    const spawn = (): void => {
+      if (queue.length === 0 && active === 0) {
+        resolve();
+        return;
+      }
+      while (active < concurrency && queue.length > 0) {
+        const id = queue.shift();
+        if (!id) break;
+        active++;
+        fetchBwb(id)
+          .catch((err) => {
+            console.error(`  FATAL ${id}: ${String(err)}`);
+          })
+          .finally(() => {
+            active--;
+            done++;
+            spawn();
+          });
+      }
+    };
+    spawn();
+  });
+  console.log(`Done: ${done} fetched (${ids.length} requested)`);
 }
 
 void main();

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "homepage": "https://ansvar.eu",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "Apache-2.0",
   "keywords": [
     "dutch-law",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "@ansvar/dutch-law-mcp",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Data refresh + version bump that delivers populated \`effective_date\` to gateway citation envelopes for every Dutch law query.

## What lands when this PR merges

1. \`package.json\` bumps to v1.2.2
2. \`publish-ghcr.yml\` triggers on the merge commit
3. Builder stage's \`download:db\` step reads v1.2.2 from package.json and pulls the v1.2.2 release asset (database.db.gz, 50 MB compressed → 129 MB SQLite)
4. New image lands in GHCR with the date-rich corpus baked in
5. Watchtower swaps prod \`law-dutch\` container
6. Gateway probes for \`get_provision(law=AVG, article=5)\` start returning \`effective_date: "2018-05-25"\` instead of \`""\`

## Process

1. Pulled the prod database (3251 BWB IDs)
2. Re-fetched each BWB XML via \`scripts/ingest-single-bwb.ts --concurrency 5\` (~12 min wall-clock with retries)
3. \`parseBwbXml\` (PR #106) extracted \`toestand@inwerkingtreding\` from each
4. \`ingest-bwb.ts\` (PR #106) wrote \`in_force_date\` into seed JSON
5. \`build-db.ts\` loaded \`in_force_date\` into \`legal_documents\`
6. Verified 100% coverage in built DB: 3251/3251 docs have date

## GitHub Release

[\`v1.2.2\`](https://github.com/Ansvar-Systems/Dutch-law-mcp/releases/tag/v1.2.2) is published with \`database.db.gz\` as the asset. The Dockerfile \`download:db\` step pulls from this tag.

## Closes

- #60 — Emit source_url + effective_date on citations (source_url was already done in #84; effective_date now ships)
- #86 — Ingestion: populate d.in_force_date so effective_date is non-empty in citations

## Test plan

- [ ] CI green on this PR
- [ ] After merge: \`Publish GHCR Image\` workflow on main succeeds
- [ ] Watchtower kick succeeds (or hourly poll picks it up); container restart with new image
- [ ] Gateway probe of \`get_provision(law=AVG, article=5)\` returns non-empty \`effective_date\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)