### PR TITLE
chore: sync license to Dutch-Auteurswet-Art-11 per arch-docs 2026-05-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ All content is sourced from authoritative Dutch legal databases:
 | **Authority**        | Ministerie van Justitie en Veiligheid / Overheid.nl |
 | **Retrieval method** | Bulk download from Wetten.overheid.nl BWB API       |
 | **Language**         | Dutch (primary)                                     |
-| **License**          | Open Government License -- Netherlands              |
+| **License**          | `Dutch-Auteurswet-Art-11` -- Dutch statutory public domain (Auteurswet Art. 11) |
 | **Coverage**         | 3,251 Dutch federal laws (100% BWB corpus)          |
 | **Last ingested**    | 2026-02-22                                          |
 
@@ -486,9 +486,9 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Legislation:** Ministerie van Justitie en Veiligheid ([Open Government License -- Netherlands](https://data.overheid.nl/en/open-government-licence-netherlands))
-- **Case Law:** Rechtspraak.nl open data
-- **EU Metadata:** EUR-Lex (EU public domain)
+- **Statutes & Legislation:** `Dutch-Auteurswet-Art-11` -- Dutch statutory public domain. Auteurswet Art. 11 (1912) states that no copyright subsists in laws, decrees or ordinances issued by public authorities, or in judicial or administrative decisions. Verified verbatim 2026-05-17 -- see [`docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md). Catalog entry: `Dutch-Auteurswet-Art-11` in `infrastructure/attribution-licenses.json`.
+- **Case Law:** Rechtspraak.nl -- same statutory basis (Auteurswet Art. 11 judicial-decision clause)
+- **EU Metadata:** EUR-Lex (EU public domain, Decision 2011/833/EU)
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -1,5 +1,11 @@
 # sources.yml — Data provenance metadata
 # Reference: docs/mcp-infrastructure-blueprint.md §3
+# License axis: Dutch-Auteurswet-Art-11 (Dutch statutory public domain)
+# Statutory basis: Auteurswet (1912) Art. 11 — no copyright subsists in laws,
+# decrees or ordinances issued by public authorities, or in judicial or
+# administrative decisions. Verified verbatim 2026-05-17.
+# Cross-ref: docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md
+# Catalog entry: infrastructure/attribution-licenses.json → "Dutch-Auteurswet-Art-11"
 
 schema_version: '1.0'
 mcp_name: 'Dutch Law MCP'
@@ -15,9 +21,9 @@ sources:
     update_frequency: 'daily'
     last_ingested: '2026-02-10'
     license_or_terms:
-      type: 'Government Open Data (CC0)'
-      url: 'https://data.overheid.nl/licenties'
-      summary: 'Dutch government open data, free to use without restrictions'
+      type: 'Dutch-Auteurswet-Art-11'
+      url: 'https://wetten.overheid.nl/jci1.3:c:BWBR0001886&artikel=11'
+      summary: 'Dutch statutory public domain (Auteurswet Art. 11). No copyright subsists in laws, decrees or ordinances issued by public authorities, or in judicial or administrative decisions. Statute-level basis on the underlying text; wetten.overheid.nl portal additionally publishes structured data under CC0 for the compilation.'
     coverage:
       scope: 'All consolidated Dutch statutes, AMvBs, ministerial regulations'
       limitations: 'Historical versions before 2002 may be incomplete'


### PR DESCRIPTION
## Summary

Replace generic license declaration with the jurisdiction-specific statutory-PD code that landed in arch-docs catalog today.

- `sources.yml` license type updated to `Dutch-Auteurswet-Art-11`
- README data-licenses block points at the statutory section and the new catalog entry

## Statutory basis

Auteurswet Art. 11 (1912) — no copyright subsists in laws, decrees or ordinances issued by public authorities, or in judicial or administrative decisions. Verified verbatim 2026-05-17.

## Scope

License-axis sync only. No corpus content, ingestion code, or runtime behaviour changes.

## Cross-references

- `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md` (arch-docs)
- `infrastructure/attribution-licenses.json` → `Dutch-Auteurswet-Art-11` (arch-docs)

## Test plan

- [ ] CI green (7 workflows + tests)
- [ ] No diff in `data/` or `src/` (license-axis only)